### PR TITLE
Add methods to generate a macro

### DIFF
--- a/README.md
+++ b/README.md
@@ -400,19 +400,6 @@ for generating code more easily, without having to rewrite everything by hand.
 For example, frameworks such as Adonis, Laravel and Symfony include features
 for generating classes.
 
-# Todos
-- [x] : Add an instance var
-- [x] : Add a class var
-- [x] : Add properties for class (`setter`, `property` and `getter`)
-- [x] : Add an enum
-- [x] : Add an annotation
-- [x] : Add a module
-- [x] : Add a struct
-- [x] : Add a macro
-- [x] : Add a lib (C binding)
-
-Once the todos have been checked, this library will be released.
-
 _Check out the references : https://crystal-lang.org/reference/1.15/syntax_and_semantics/index.html_
 
 If there's something missing from the todo, don't hesitate to add it.

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ library : [nette/php-generator](https://github.com/nette/php-generator).
 - [Contributing](#contributing)
 - [Contributors](#contributors)
 - [Lib C-binding](#lib-c-binding)
+- [Macro](#macro)
 
 ## Installation
 
@@ -329,8 +330,6 @@ end
 > [!TIP]
 > You can add many objects as you want into that module, thanks to `add_object` method.
 
-> More examples will be added soon.
-
 ### Lib C-binding
 
 ```crystal
@@ -367,6 +366,33 @@ lib C
 end
 ```
 
+### Macro
+
+```crystal
+macro_type = Crygen::Types::Macro.new("example")
+macro_type.add_arg("name")
+macro_type.add_arg("value")
+macro_type.body = <<-CRYSTAL
+{% for i in 1..10 %}
+  puts {{ name }}
+  puts {{ value }}
+  puts {{ "Hello world" }}
+{% end %}
+CRYSTAL
+
+puts macro_type.generate
+```
+
+Output : 
+
+```crystal
+macro example(name, value)
+  {% for i in 1..10 %}
+    puts {{ "Hello world" }}
+  {% end %}
+end
+```
+
 ## Usage
 
 This library can be used to save time. In particular, the frameworks have features
@@ -382,7 +408,7 @@ for generating classes.
 - [x] : Add an annotation
 - [x] : Add a module
 - [x] : Add a struct
-- [ ] : Add a macro
+- [x] : Add a macro
 - [x] : Add a lib (C binding)
 
 Once the todos have been checked, this library will be released.

--- a/spec/macro_spec.cr
+++ b/spec/macro_spec.cr
@@ -1,0 +1,68 @@
+require "./spec_helper"
+
+describe Crygen::Types::Macro do
+  it "creates a macro" do
+    macro_type = Crygen::Types::Macro.new("example")
+    macro_type.generate.should eq(<<-CRYSTAL)
+    macro example
+    end
+    CRYSTAL
+  end
+
+  it "creates a macro with one arg" do
+    macro_type = Crygen::Types::Macro.new("example")
+    macro_type.add_arg("name")
+    macro_type.generate.should eq(<<-CRYSTAL)
+    macro example(name)
+    end
+    CRYSTAL
+  end
+
+  it "creates a macro with many args" do
+    macro_type = Crygen::Types::Macro.new("example")
+    macro_type.add_arg("name")
+    macro_type.add_arg("value")
+    macro_type.generate.should eq(<<-CRYSTAL)
+    macro example(name, value)
+    end
+    CRYSTAL
+  end
+
+  it "creates a macro with body (one line)" do
+    macro_type = Crygen::Types::Macro.new("example")
+    macro_type.add_arg("name")
+    macro_type.add_arg("value")
+    macro_type.add_body("puts {{ name }}")
+    macro_type.add_body("puts {{ value }}")
+    macro_type.add_body("puts {{ \"Hello world\" }}")
+    macro_type.generate.should eq(<<-CRYSTAL)
+    macro example(name, value)
+      puts {{ name }}
+      puts {{ value }}
+      puts {{ "Hello world" }}
+    end
+    CRYSTAL
+  end
+
+  it "creates a macro with body (multi line)" do
+    macro_type = Crygen::Types::Macro.new("example")
+    macro_type.add_arg("name")
+    macro_type.add_arg("value")
+    macro_type.body = <<-CRYSTAL
+    {% for i in 1..10 %}
+      puts {{ name }}
+      puts {{ value }}
+      puts {{ "Hello world" }}
+    {% end %}
+    CRYSTAL
+    macro_type.generate.should eq(<<-CRYSTAL)
+    macro example(name, value)
+      {% for i in 1..10 %}
+        puts {{ name }}
+        puts {{ value }}
+        puts {{ "Hello world" }}
+      {% end %}
+    end
+    CRYSTAL
+  end
+end

--- a/src/types/macro.cr
+++ b/src/types/macro.cr
@@ -1,0 +1,59 @@
+require "./../interfaces/generator"
+require "./../modules/arg"
+
+# A class that generates a macro
+# ```
+# macro_type = CGT::Macro.new("example")
+# macro_type.add_arg("name")
+# puts macro_type.generate
+# ```
+# Output :
+# ```
+# macro example(name)
+#   puts {{ name }}
+# end
+# ```
+class Crygen::Types::Macro < Crygen::Abstract::GeneratorInterface
+  @args = [] of String
+  @body = ""
+
+  def initialize(@name : String); end
+
+  # Adds an argument to the macro.
+  def add_arg(arg : String) : Nil
+    @args << arg
+  end
+
+  # Adds a new line into the macro body.
+  def add_body(line : String) : Nil
+    @body += line + "\n"
+  end
+
+  # Write the macro body.
+  def body=(body : String) : Nil
+    @body = body
+  end
+
+  # Generates the macro.
+  def generate : String
+    String.build do |str|
+      str << "macro #{@name}"
+      str << generate_args unless @args.empty?
+      str << "\n"
+      @body.each_line { |line| str << "  #{line}\n" }
+      str << "end"
+    end
+  end
+
+  # Generate the args.
+  private def generate_args : String
+    String.build do |str|
+      str << '(' unless @args.empty?
+      @args.each_with_index do |arg, i|
+        str << "#{arg}"
+        str << ", " if i != @args.size - 1
+      end
+      str << ')' unless @args.empty?
+    end
+  end
+end


### PR DESCRIPTION
## Description

Generate a macro where it is possible to add args and write body.

## Code generation

```crystal
macro_type = CGT::Macro.new("example")
macro_type.add_arg("name")
macro_type.add_arg("value")
macro_type.body = <<-CRYSTAL
{% for i in 1..10 %}
  puts {{ name }}
  puts {{ value }}
  puts {{ "Hello world" }}
{% end %}
CRYSTAL

puts macro_type.generate
```

## Code output
```crystal
macro example(name, value)
  {% for i in 1..10 %}
    puts {{ "Hello world" }}
  {% end %}
end
```