### PR TITLE
Add enum for properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,9 @@ You can add properties in the class, for example :
 # Create a class with one comment and a method.
 class_person = CGT::Class.new("Person")
 class_person.add_comment("This is a class called Person.")
-class_type.add_property(:property, "full_name", "String")
-class_type.add_property(:getter, "first_name", "String")
-class_type.add_property(:setter, "last_name", "String")
+class_type.add_property(CGE::PropVisibility::Property, "full_name", "String")
+class_type.add_property(CGE::PropVisibility::Getter, "first_name", "String")
+class_type.add_property(CGE::PropVisibility::Setter, "last_name", "String")
 
 # Print the generated code.
 puts class_person.generate

--- a/spec/class/class_spec.cr
+++ b/spec/class/class_spec.cr
@@ -96,9 +96,9 @@ describe Crygen::Types::Class do
 
   it "creates a class with properties" do
     class_type = test_person_class()
-    class_type.add_property(:property, "full_name", "String")
-    class_type.add_property(:getter, "first_name", "String")
-    class_type.add_property(:setter, "last_name", "String")
+    class_type.add_property(CGE::PropVisibility::Property, "full_name", "String")
+    class_type.add_property(CGE::PropVisibility::Getter, "first_name", "String")
+    class_type.add_property(CGE::PropVisibility::Setter, "last_name", "String")
 
     class_type.generate.should eq(<<-CRYSTAL)
     class Person

--- a/spec/class/class_spec.cr
+++ b/spec/class/class_spec.cr
@@ -107,5 +107,18 @@ describe Crygen::Types::Class do
       setter last_name : String
     end
     CRYSTAL
+
+    class_type = test_person_class()
+    class_type.add_property(:property, "full_name", "String")
+    class_type.add_property(:getter, "first_name", "String")
+    class_type.add_property(:setter, "last_name", "String")
+
+    class_type.generate.should eq(<<-CRYSTAL)
+    class Person
+      property full_name : String
+      getter first_name : String
+      setter last_name : String
+    end
+    CRYSTAL
   end
 end

--- a/spec/struct/struct_spec.cr
+++ b/spec/struct/struct_spec.cr
@@ -96,9 +96,9 @@ describe Crygen::Types::Struct do
 
   it "creates a struct with properties" do
     struct_type = test_point_struct()
-    struct_type.add_property(:property, "x", "Int32")
-    struct_type.add_property(:getter, "y", "Int32")
-    struct_type.add_property(:setter, "z", "Int32")
+    struct_type.add_property(CGE::PropVisibility::Property, "x", "Int32")
+    struct_type.add_property(CGE::PropVisibility::Getter, "y", "Int32")
+    struct_type.add_property(CGE::PropVisibility::Setter, "z", "Int32")
 
     struct_type.generate.should eq(<<-CRYSTAL)
     struct Point

--- a/spec/struct/struct_spec.cr
+++ b/spec/struct/struct_spec.cr
@@ -107,5 +107,18 @@ describe Crygen::Types::Struct do
       setter z : Int32
     end
     CRYSTAL
+
+    struct_type = test_point_struct()
+    struct_type.add_property(:property, "x", "Int32")
+    struct_type.add_property(:getter, "y", "Int32")
+    struct_type.add_property(:setter, "z", "Int32")
+
+    struct_type.generate.should eq(<<-CRYSTAL)
+    struct Point
+      property x : Int32
+      getter y : Int32
+      setter z : Int32
+    end
+    CRYSTAL
   end
 end

--- a/src/crygen.cr
+++ b/src/crygen.cr
@@ -9,4 +9,7 @@ module Crygen
 
   # CGT is an alias of "**C**ry**G**en **T**ypes".
   alias ::CGT = Crygen::Types
+
+  # CGE is an alias of "**C**ry**G**en **E**nums".
+  alias ::CGE = Crygen::Enums
 end

--- a/src/enums/property_visibility.cr
+++ b/src/enums/property_visibility.cr
@@ -1,4 +1,5 @@
 # An enum that identifies the property visibility like public, protected and private.
+@[Flags]
 enum Crygen::Enums::PropVisibility
   Getter
   Property

--- a/src/enums/property_visibility.cr
+++ b/src/enums/property_visibility.cr
@@ -1,0 +1,6 @@
+# An enum that identifies the property visibility like public, protected and private.
+enum Crygen::Enums::PropVisibility
+  Getter
+  Property
+  Setter
+end

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -1,16 +1,17 @@
+require "./../enums/property_visibility"
 require "./scope"
 
 module Crygen::Modules::Property
   @properties = [] of Hash(Symbol, String | Symbol | Nil)
 
   # Adds a property into object (visibility, name and type)
-  def add_property(visibility : Symbol, name : String, type : String) : Nil
-    @properties << {:scope => :public, :visibility => visibility, :name => name, :type => type, :value => nil}
+  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String) : Nil
+    @properties << {:scope => :public, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => nil}
   end
 
   # Adds a property into object (visibility, name, type and value)
-  def add_property(visibility : Symbol, name : String, type : String, value : String) : Nil
-    @properties << {:scope => :public, :visibility => visibility, :name => name, :type => type, :value => value}
+  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, value : String) : Nil
+    @properties << {:scope => :public, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => value}
   end
 
   # Generates the properties.


### PR DESCRIPTION
## Description
Overloaded `add_property` methods have a `visibility` argument of type `Symbol`. However, this argument can add any name in addition to the `getter`, `property` and `setter` values.
To solve this problem, an enum `Crygen::Enums::PropVisibility` is added to limit the number of names to the 3 mentioned above.

## Changelog
- `visibility` arg type has changed into `Crygen::Enums::PropVisibility` enum.

## Issue reference
Visibility name of the property can be anything : #4