### PR TITLE
Change the return type for methods

### DIFF
--- a/spec/annotation_spec.cr
+++ b/spec/annotation_spec.cr
@@ -2,25 +2,19 @@ require "./spec_helper"
 
 describe Crygen::Types::Enum do
   it "creates an annotation" do
-    annotation_type = Crygen::Types::Annotation.new("MyAnnotation")
-
-    annotation_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::Annotation.new("MyAnnotation").generate.should eq(<<-CRYSTAL)
     @[MyAnnotation]
     CRYSTAL
   end
 
   it "creates an annotation with one parameter (value only)" do
-    annotation_type = Crygen::Types::Annotation.new("MyAnnotation")
-    annotation_type.add_arg("true")
-    annotation_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::Annotation.new("MyAnnotation").add_arg("true").generate.should eq(<<-CRYSTAL)
     @[MyAnnotation(true)]
     CRYSTAL
   end
 
   it "creates an annotation with one parameter (name and value)" do
-    annotation_type = Crygen::Types::Annotation.new("MyAnnotation")
-    annotation_type.add_arg("is_cool", "true")
-    annotation_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::Annotation.new("MyAnnotation").add_arg("is_cool", "true").generate.should eq(<<-CRYSTAL)
     @[MyAnnotation(is_cool: true)]
     CRYSTAL
   end

--- a/spec/class/abstract_class_spec.cr
+++ b/spec/class/abstract_class_spec.cr
@@ -3,9 +3,7 @@ require "./../spec_helper"
 describe Crygen::Types::Class do
   describe "abstract class" do
     it "creates an abstract class" do
-      class_type = test_person_class()
-      class_type.as_abstract
-      class_type.generate.should eq(<<-CRYSTAL)
+      test_person_class().as_abstract.generate.should eq(<<-CRYSTAL)
       abstract class Person
       end
       CRYSTAL
@@ -23,11 +21,12 @@ describe Crygen::Types::Class do
     end
 
     it "creates an abstract class with many abstract methods" do
+      first_name_method = CGT::Method.new("first_name", "String")
+      last_name_method = CGT::Method.new("last_name", "String")
+      full_name_method = CGT::Method.new("full_name", "String")
       class_type = test_person_class()
       class_type.as_abstract
-      class_type.add_method(CGT::Method.new("first_name", "String"))
-      class_type.add_method(CGT::Method.new("last_name", "String"))
-      class_type.add_method(CGT::Method.new("full_name", "String"))
+      class_type.add_method(first_name_method).add_method(last_name_method).add_method(full_name_method)
       class_type.generate.should eq(<<-CRYSTAL)
       abstract class Person
         abstract def first_name : String
@@ -49,9 +48,7 @@ describe Crygen::Types::Class do
     end
 
     it "creates an abstract class with multiple lines comment" do
-      class_type = test_person_class()
-      class_type.as_abstract
-      class_type.add_comment(<<-STR)
+      class_type = test_person_class().as_abstract.add_comment(<<-STR)
       This is a multiline comment.
       The name class is Person.
       STR

--- a/spec/class/class_class_vars_spec.cr
+++ b/spec/class/class_class_vars_spec.cr
@@ -2,9 +2,7 @@ require "./../spec_helper"
 
 describe "(class vars only)" do
   it "creates a class with one class var" do
-    class_type = test_person_class()
-    class_type.add_class_var("full_name", "String")
-    class_type.generate.should eq(<<-CRYSTAL)
+    test_person_class().add_class_var("full_name", "String").generate.should eq(<<-CRYSTAL)
     class Person
       @@full_name : String
     end
@@ -12,9 +10,7 @@ describe "(class vars only)" do
   end
 
   it "creates a class with one class var with the default value" do
-    class_type = test_person_class()
-    class_type.add_class_var("full_name", "String", "John Doe")
-    class_type.generate.should eq(<<-CRYSTAL)
+    test_person_class().add_class_var("full_name", "String", "John Doe").generate.should eq(<<-CRYSTAL)
     class Person
       @@full_name : String = "John Doe"
     end

--- a/spec/class/class_instance_vars_spec.cr
+++ b/spec/class/class_instance_vars_spec.cr
@@ -3,9 +3,7 @@ require "./../spec_helper"
 describe Crygen::Types::Class do
   describe "(instance vars only)" do
     it "creates a class with one instance var" do
-      class_type = test_person_class()
-      class_type.add_instance_var("full_name", "String")
-      class_type.generate.should eq(<<-CRYSTAL)
+      test_person_class().add_instance_var("full_name", "String").generate.should eq(<<-CRYSTAL)
       class Person
         @full_name : String
       end
@@ -13,9 +11,7 @@ describe Crygen::Types::Class do
     end
 
     it "creates a class with one instance var with the default value" do
-      class_type = test_person_class()
-      class_type.add_instance_var("full_name", "String", "John Doe")
-      class_type.generate.should eq(<<-CRYSTAL)
+      test_person_class().add_instance_var("full_name", "String", "John Doe").generate.should eq(<<-CRYSTAL)
       class Person
         @full_name : String = "John Doe"
       end

--- a/spec/class/class_spec.cr
+++ b/spec/class/class_spec.cr
@@ -2,8 +2,7 @@ require "./../spec_helper"
 
 describe Crygen::Types::Class do
   it "creates a class" do
-    class_type = test_person_class()
-    class_type.generate.should eq(<<-CRYSTAL)
+    test_person_class().generate.should eq(<<-CRYSTAL)
     class Person
     end
     CRYSTAL

--- a/spec/libc_spec.cr
+++ b/spec/libc_spec.cr
@@ -2,17 +2,14 @@ require "./spec_helper"
 
 describe Crygen::Types::LibC do
   it "creates a C library" do
-    libc_type = Crygen::Types::LibC.new("C")
-    libc_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::LibC.new("C").generate.should eq(<<-CRYSTAL)
     lib C
     end
     CRYSTAL
   end
 
   it "creates a C library with one function" do
-    libc_type = Crygen::Types::LibC.new("C")
-    libc_type.add_function("getch", "Int32")
-    libc_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::LibC.new("C").add_function("getch", "Int32").generate.should eq(<<-CRYSTAL)
     lib C
       fun getch : Int32
     end
@@ -20,9 +17,7 @@ describe Crygen::Types::LibC do
   end
 
   it "creates a C library with one function and a parameter" do
-    libc_type = Crygen::Types::LibC.new("C")
-    libc_type.add_function("getch", "Int32", [{"arg", "String"}])
-    libc_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::LibC.new("C").add_function("getch", "Int32", [{"arg", "String"}]).generate.should eq(<<-CRYSTAL)
     lib C
       fun getch(arg : String) : Int32
     end

--- a/spec/macro_spec.cr
+++ b/spec/macro_spec.cr
@@ -2,17 +2,14 @@ require "./spec_helper"
 
 describe Crygen::Types::Macro do
   it "creates a macro" do
-    macro_type = Crygen::Types::Macro.new("example")
-    macro_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::Macro.new("example").generate.should eq(<<-CRYSTAL)
     macro example
     end
     CRYSTAL
   end
 
   it "creates a macro with one arg" do
-    macro_type = Crygen::Types::Macro.new("example")
-    macro_type.add_arg("name")
-    macro_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::Macro.new("example").add_arg("name").generate.should eq(<<-CRYSTAL)
     macro example(name)
     end
     CRYSTAL

--- a/spec/method_spec.cr
+++ b/spec/method_spec.cr
@@ -2,8 +2,7 @@ require "./spec_helper"
 
 describe Crygen::Types::Method do
   it "creates a public method" do
-    method_type = CGT::Method.new("full_name", "String")
-    method_type.generate.should eq(<<-CRYSTAL)
+    CGT::Method.new("full_name", "String").generate.should eq(<<-CRYSTAL)
     def full_name : String
     end
     CRYSTAL
@@ -46,36 +45,28 @@ describe Crygen::Types::Method do
   end
 
   it "creates a protected method" do
-    method_type = CGT::Method.new("date_birth", "String")
-    method_type.as_protected
-    method_type.generate.should eq(<<-CRYSTAL)
+    CGT::Method.new("date_birth", "String").as_protected.generate.should eq(<<-CRYSTAL)
     protected def date_birth : String
     end
     CRYSTAL
   end
 
   it "creates a private method" do
-    method_type = CGT::Method.new("date_birth", "String")
-    method_type.as_private
-    method_type.generate.should eq(<<-CRYSTAL)
+    CGT::Method.new("date_birth", "String").as_private.generate.should eq(<<-CRYSTAL)
     private def date_birth : String
     end
     CRYSTAL
   end
 
   it "creates a method with one arg" do
-    method_type = CGT::Method.new("major?", "Bool")
-    method_type.add_arg("age", "Int8")
-    method_type.generate.should eq(<<-CRYSTAL)
+    CGT::Method.new("major?", "Bool").add_arg("age", "Int8").generate.should eq(<<-CRYSTAL)
     def major?(age : Int8) : Bool
     end
     CRYSTAL
   end
 
   it "creates a method with one default value arg" do
-    method_type = CGT::Method.new("major?", "Bool")
-    method_type.add_arg("age", "Int8", "22")
-    method_type.generate.should eq(<<-CRYSTAL)
+    CGT::Method.new("major?", "Bool").add_arg("age", "Int8", "22").generate.should eq(<<-CRYSTAL)
     def major?(age : Int8 = 22) : Bool
     end
     CRYSTAL

--- a/spec/module_spec.cr
+++ b/spec/module_spec.cr
@@ -2,16 +2,14 @@ require "./spec_helper"
 
 describe Crygen::Types::Module do
   it "creates a module with simple name" do
-    module_type = Crygen::Types::Module.new("Folder")
-    module_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::Module.new("Folder").generate.should eq(<<-CRYSTAL)
     module Folder
     end
     CRYSTAL
   end
 
   it "creates a module with long name" do
-    module_type = Crygen::Types::Module.new("Folder::Sub::Folder")
-    module_type.generate.should eq(<<-CRYSTAL)
+    Crygen::Types::Module.new("Folder::Sub::Folder").generate.should eq(<<-CRYSTAL)
     module Folder::Sub::Folder
     end
     CRYSTAL

--- a/spec/struct/struct_class_vars_spec.cr
+++ b/spec/struct/struct_class_vars_spec.cr
@@ -2,9 +2,7 @@ require "./../spec_helper"
 
 describe "(class vars only)" do
   it "creates a struct with one class var" do
-    struct_type = test_point_struct()
-    struct_type.add_class_var("full_name", "String")
-    struct_type.generate.should eq(<<-CRYSTAL)
+    test_point_struct().add_class_var("full_name", "String").generate.should eq(<<-CRYSTAL)
     struct Point
       @@full_name : String
     end
@@ -12,9 +10,7 @@ describe "(class vars only)" do
   end
 
   it "creates a struct with one class var with the default value" do
-    struct_type = test_point_struct()
-    struct_type.add_class_var("full_name", "String", "John Doe")
-    struct_type.generate.should eq(<<-CRYSTAL)
+    test_point_struct().add_class_var("full_name", "String", "John Doe").generate.should eq(<<-CRYSTAL)
     struct Point
       @@full_name : String = "John Doe"
     end

--- a/spec/struct/struct_instance_vars_spec.cr
+++ b/spec/struct/struct_instance_vars_spec.cr
@@ -3,9 +3,7 @@ require "./../spec_helper"
 describe Crygen::Types::Struct do
   describe "(instance vars only)" do
     it "creates a struct with one instance var" do
-      struct_type = test_point_struct()
-      struct_type.add_instance_var("full_name", "String")
-      struct_type.generate.should eq(<<-CRYSTAL)
+      test_point_struct().add_instance_var("full_name", "String").generate.should eq(<<-CRYSTAL)
       struct Point
         @full_name : String
       end
@@ -13,9 +11,7 @@ describe Crygen::Types::Struct do
     end
 
     it "creates a struct with one instance var with the default value" do
-      struct_type = test_point_struct()
-      struct_type.add_instance_var("full_name", "String", "John Doe")
-      struct_type.generate.should eq(<<-CRYSTAL)
+      test_point_struct().add_instance_var("full_name", "String", "John Doe").generate.should eq(<<-CRYSTAL)
       struct Point
         @full_name : String = "John Doe"
       end

--- a/spec/struct/struct_spec.cr
+++ b/spec/struct/struct_spec.cr
@@ -2,17 +2,14 @@ require "./../spec_helper"
 
 describe Crygen::Types::Struct do
   it "creates a class" do
-    struct_type = test_point_struct()
-    struct_type.generate.should eq(<<-CRYSTAL)
+    test_point_struct().generate.should eq(<<-CRYSTAL)
     struct Point
     end
     CRYSTAL
   end
 
   it "creates a class with one annotation" do
-    struct_type = test_point_struct()
-    struct_type.add_annotation(CGT::Annotation.new("Experimental"))
-    struct_type.generate.should eq(<<-CRYSTAL)
+    test_point_struct().add_annotation(CGT::Annotation.new("Experimental")).generate.should eq(<<-CRYSTAL)
     @[Experimental]
     struct Point
     end
@@ -32,9 +29,7 @@ describe Crygen::Types::Struct do
   end
 
   it "creates a class with one line comment" do
-    struct_type = test_point_struct()
-    struct_type.add_comment("This is an example class concerning a person.")
-    struct_type.generate.should eq(<<-CRYSTAL)
+    test_point_struct().add_comment("This is an example class concerning a person.").generate.should eq(<<-CRYSTAL)
     # This is an example class concerning a person.
     struct Point
     end

--- a/src/modules/arg.cr
+++ b/src/modules/arg.cr
@@ -2,13 +2,15 @@ module Crygen::Modules::Arg
   @args = [] of Tuple(String, String, String | Nil)
 
   # Add an argument with no default value.
-  def add_arg(name : String, type : String) : Nil
+  def add_arg(name : String, type : String) : self
     @args << {name, type, nil}
+    self
   end
 
   # Add an argument with default value.
-  def add_arg(name : String, type : String, value : String) : Nil
+  def add_arg(name : String, type : String, value : String) : self
     @args << {name, type, value}
+    self
   end
 
   # Generate the args

--- a/src/modules/class_var.cr
+++ b/src/modules/class_var.cr
@@ -2,17 +2,19 @@ module Crygen::Modules::ClassVar
   @class_vars = [] of Tuple(String, String, String | Nil)
 
   # Adds a class var with no default value.
-  def add_class_var(name : String, type : String) : Nil
+  def add_class_var(name : String, type : String) : self
     @class_vars << {name, type, nil}
+    self
   end
 
   # Adds a class var with default value.
-  def add_class_var(name : String, type : String, value : String) : Nil
+  def add_class_var(name : String, type : String, value : String) : self
     if type == "String"
       @class_vars << {name, type, value.dump}
     else
       @class_vars << {name, type, value}
     end
+    self
   end
 
   # Generate the class_vars

--- a/src/modules/comment.cr
+++ b/src/modules/comment.cr
@@ -4,9 +4,10 @@ module Crygen::Modules::Comment
   @comments = [] of String
 
   # Add a line or multiline comment on an object.
-  def add_comment(value : String) : Nil
+  def add_comment(value : String) : self
     value.each_line do |line|
       @comments << line
     end
+    self
   end
 end

--- a/src/modules/instance_var.cr
+++ b/src/modules/instance_var.cr
@@ -2,17 +2,19 @@ module Crygen::Modules::InstanceVar
   @instance_vars = [] of Tuple(String, String, String | Nil)
 
   # Add an argument with no default value.
-  def add_instance_var(name : String, type : String) : Nil
+  def add_instance_var(name : String, type : String) : self
     @instance_vars << {name, type, nil}
+    self
   end
 
   # Add an argument with default value.
-  def add_instance_var(name : String, type : String, value : String) : Nil
+  def add_instance_var(name : String, type : String, value : String) : self
     if type == "String"
       @instance_vars << {name, type, value.dump}
     else
       @instance_vars << {name, type, value}
     end
+    self
   end
 
   # Generate the instance_vars

--- a/src/modules/method.cr
+++ b/src/modules/method.cr
@@ -4,7 +4,8 @@ module Crygen::Modules::Method
   @methods = [] of Crygen::Types::Method
 
   # Adds an method into class.
-  def add_method(method : Crygen::Types::Method) : Nil
+  def add_method(method : Crygen::Types::Method) : self
     @methods << method
+    self
   end
 end

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -5,13 +5,15 @@ module Crygen::Modules::Property
   @properties = [] of Hash(Symbol, String | Symbol | Nil)
 
   # Adds a property into object (visibility, name and type)
-  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String) : Nil
+  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String) : self
     @properties << {:scope => :public, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => nil}
+    self
   end
 
   # Adds a property into object (visibility, name, type and value)
-  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, value : String) : Nil
+  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, value : String) : self
     @properties << {:scope => :public, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => value}
+    self
   end
 
   # Generates the properties.

--- a/src/modules/scope.cr
+++ b/src/modules/scope.cr
@@ -2,12 +2,14 @@ module Crygen::Modules::Scope
   @scope : Symbol = :public
 
   # Set the scope as protected.
-  def as_protected : Nil
+  def as_protected : self
     @scope = :protected
+    self
   end
 
   # Set the scope as private.
-  def as_private : Nil
+  def as_private : self
     @scope = :private
+    self
   end
 end

--- a/src/types/annotation.cr
+++ b/src/types/annotation.cr
@@ -30,8 +30,9 @@ class Crygen::Types::Annotation < Crygen::Abstract::GeneratorInterface
   # ```
   # @[MyAnnotation(true)]
   # ```
-  def add_arg(value : String) : Nil
+  def add_arg(value : String) : self
     @args << {nil, value}
+    self
   end
 
   # Adds a name and value into the argument.
@@ -43,8 +44,9 @@ class Crygen::Types::Annotation < Crygen::Abstract::GeneratorInterface
   # ```
   # @[MyAnnotation(full_name: "John Doe")]
   # ```
-  def add_arg(name : String, value : String) : Nil
+  def add_arg(name : String, value : String) : self
     @args << {name, value}
+    self
   end
 
   # Generates an annotation.

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -39,8 +39,9 @@ class Crygen::Types::Class < Crygen::Abstract::GeneratorInterface
   # class_type.add_annotation(CGT::Annotation.new("Experimental"))
   # class_type.add_annotation(CGT::Annotation.new("AnotherAnnotation"))
   # ```
-  def add_annotation(annotation_type : Crygen::Types::Annotation) : Nil
+  def add_annotation(annotation_type : Crygen::Types::Annotation) : self
     @annotations << annotation_type
+    self
   end
 
   # Set as an abstract class.
@@ -48,8 +49,9 @@ class Crygen::Types::Class < Crygen::Abstract::GeneratorInterface
   # class_type = CGT::Class.new("Person")
   # class_type.as_abstract
   # ```
-  def as_abstract : Nil
+  def as_abstract : self
     @type = :abstract
+    self
   end
 
   # Generates a Crystal code.

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -30,8 +30,9 @@ class Crygen::Types::Enum
   # enum_type = Crygen::Types::Enum.new("Person")
   # enum_type.add_constant("Employee")
   # ```
-  def add_constant(name : String) : Nil
+  def add_constant(name : String) : self
     @constants << {name, nil}
+    self
   end
 
   # Adds a constant into enum (name and value).
@@ -39,8 +40,9 @@ class Crygen::Types::Enum
   # enum_type = Crygen::Types::Enum.new("Person")
   # enum_type.add_constant("Employee", 1)
   # ```
-  def add_constant(name : String, value : String) : Nil
+  def add_constant(name : String, value : String) : self
     @constants << {name, value}
+    self
   end
 
   # Generates an enum.

--- a/src/types/libc.cr
+++ b/src/types/libc.cr
@@ -22,22 +22,25 @@ class Crygen::Types::LibC < Crygen::Abstract::GeneratorInterface
   def initialize(@name : String); end
 
   # Adds a C function (name and return type).
-  def add_function(name : String, return_type : String, args : Array(Tuple(String, String)) | Nil = nil) : Nil
+  def add_function(name : String, return_type : String, args : Array(Tuple(String, String)) | Nil = nil) : self
     @functions << {
       :name        => name,
       :args        => !args.nil? ? generate_args(args) : "",
       :return_type => return_type,
     }
+    self
   end
 
   # Adds a struct.
-  def add_struct(name : String, fields : FieldArray) : Nil
+  def add_struct(name : String, fields : FieldArray) : self
     @objects << {name, :struct, fields}
+    self
   end
 
   # Adds an union.
-  def add_union(name : String, fields : FieldArray) : Nil
+  def add_union(name : String, fields : FieldArray) : self
     @objects << {name, :union, fields}
+    self
   end
 
   # Generates a C lib.

--- a/src/types/macro.cr
+++ b/src/types/macro.cr
@@ -20,18 +20,21 @@ class Crygen::Types::Macro < Crygen::Abstract::GeneratorInterface
   def initialize(@name : String); end
 
   # Adds an argument to the macro.
-  def add_arg(arg : String) : Nil
+  def add_arg(arg : String) : self
     @args << arg
+    self
   end
 
   # Adds a new line into the macro body.
-  def add_body(line : String) : Nil
+  def add_body(line : String) : self
     @body += line + "\n"
+    self
   end
 
   # Write the macro body.
-  def body=(body : String) : Nil
+  def body=(body : String) : self
     @body = body
+    self
   end
 
   # Generates the macro.

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -30,8 +30,9 @@ class Crygen::Types::Method < Crygen::Abstract::GeneratorInterface
   # method_type = CGT::Method.new("full_name", "String")
   # method_type.add_annotation(CGT::Annotation.new("Experimental"))
   # ```
-  def add_annotation(annotation_type : Crygen::Types::Annotation) : Nil
+  def add_annotation(annotation_type : Crygen::Types::Annotation) : self
     @annotations << annotation_type
+    self
   end
 
   # Add a code into method.
@@ -39,8 +40,9 @@ class Crygen::Types::Method < Crygen::Abstract::GeneratorInterface
   # method_type = CGT::Method.new("full_name", "String")
   # method_type.add_body("Hello world".dump)
   # ```
-  def add_body(body : String) : Nil
+  def add_body(body : String) : self
     @body += body
+    self
   end
 
   # Generates the methods.

--- a/src/types/module.cr
+++ b/src/types/module.cr
@@ -33,8 +33,9 @@ class Crygen::Types::Module < Crygen::Abstract::GeneratorInterface
   def initialize(@name : String); end
 
   # Adds an object into the module.
-  def add_object(object_type : ObjectType)
+  def add_object(object_type : ObjectType) : self
     @objects << object_type
+    self
   end
 
   # Generates a module.

--- a/src/types/struct.cr
+++ b/src/types/struct.cr
@@ -36,8 +36,9 @@ class Crygen::Types::Struct < Crygen::Abstract::GeneratorInterface
   # struct_type = CGT::Struct.new("Point")
   # struct_type.add_annotation(CGT::Annotation.new("Experimental"))
   # ```
-  def add_annotation(annotation_type : Crygen::Types::Annotation) : Nil
+  def add_annotation(annotation_type : Crygen::Types::Annotation) : self
     @annotations << annotation_type
+    self
   end
 
   # Generates a struct.


### PR DESCRIPTION
## Description
This change modifies the return type of all methods in this library. Instead of returning `Nil`, they return the object of a class. This favors the “Fluent” design pattern. Thanks to this latter, we can directly generate a code without having to create a variable.
```crystal
Crygen::Types::Annotation.new("MyAnnotation").add_arg("true").generate.should eq(<<-CRYSTAL)
# => Output : @[MyAnnotation(true)]
```

## Changelog
- Change the return type to `self` instead of `Nil`

## Issue reference(s)
Return type is nil : #7
