### PR TITLE
Add an optional argument to define the property scope

### DIFF
--- a/spec/class/class_spec.cr
+++ b/spec/class/class_spec.cr
@@ -120,4 +120,19 @@ describe Crygen::Types::Class do
     end
     CRYSTAL
   end
+
+  it "creates a class with scoped properties" do
+    class_type = test_person_class()
+    class_type.add_property(:property, "full_name", "String")
+    class_type.add_property(:getter, "first_name", "String", :protected)
+    class_type.add_property(:setter, "last_name", "String", :private)
+
+    class_type.generate.should eq(<<-CRYSTAL)
+    class Person
+      property full_name : String
+      protected getter first_name : String
+      private setter last_name : String
+    end
+    CRYSTAL
+  end
 end

--- a/spec/struct/struct_spec.cr
+++ b/spec/struct/struct_spec.cr
@@ -116,4 +116,19 @@ describe Crygen::Types::Struct do
     end
     CRYSTAL
   end
+
+  it "creates a struct with scoped properties" do
+    struct_type = test_point_struct()
+    struct_type.add_property(:property, "x", "Int32")
+    struct_type.add_property(:getter, "y", "Int32", :protected)
+    struct_type.add_property(:setter, "z", "Int32", :private)
+
+    struct_type.generate.should eq(<<-CRYSTAL)
+    struct Point
+      property x : Int32
+      protected getter y : Int32
+      private setter z : Int32
+    end
+    CRYSTAL
+  end
 end

--- a/src/enums/prop_scope.cr
+++ b/src/enums/prop_scope.cr
@@ -1,0 +1,7 @@
+# An enum that identifies the property scope like public, protected and private.
+@[Flags]
+enum Crygen::Enums::PropScope
+  Public
+  Protected
+  Private
+end

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -1,18 +1,31 @@
 require "./../enums/prop_visibility"
+require "./../enums/prop_scope"
 require "./scope"
 
 module Crygen::Modules::Property
-  @properties = [] of Hash(Symbol, String | Symbol | Nil)
+  @properties = [] of Hash(Symbol, String | Nil)
 
   # Adds a property into object (visibility, name and type)
   def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String) : self
-    @properties << {:scope => :public, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => nil}
+    @properties << {:scope => "public", :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => nil}
+    self
+  end
+
+  # Adds a property into object (visibility, name, type and scope).
+  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, scope : Crygen::Enums::PropScope = :public) : self
+    @properties << {:scope => scope.to_s.downcase, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => nil}
     self
   end
 
   # Adds a property into object (visibility, name, type and value)
   def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, value : String) : self
-    @properties << {:scope => :public, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => value}
+    @properties << {:scope => "public", :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => value}
+    self
+  end
+
+  # Adds a property into object (visibility, name, type, value and scope)
+  def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, value : String, scope : Crygen::Enums::PropScope = :public) : self
+    @properties << {:scope => scope.to_s.downcase, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => value}
     self
   end
 
@@ -20,6 +33,10 @@ module Crygen::Modules::Property
   protected def generate_properties : String
     String.build do |str|
       @properties.each do |prop|
+        unless prop[:scope] == "public"
+          str << prop[:scope]
+          str << ' '
+        end
         str << "#{prop[:visibility]} #{prop[:name]}"
         str << " : #{prop[:type]}" if prop[:visibility]
         str << " = #{prop[:value]}" if prop[:value]


### PR DESCRIPTION
## Description
Add an optional argument to define the property's scope. Indeed, we can add a protected and/or private property. This allows to modify the scope of a getter and/or setter.

```crystal
class_type = test_person_class()
class_type.add_property(:property, "full_name", "String")
class_type.add_property(:getter, "first_name", "String", :protected)
class_type.add_property(:setter, "last_name", "String", :private)
puts class_type.generate
```

```crystal
class Person
  property full_name : String
  protected getter first_name : String
  private setter last_name : String
end
```

## Changelog
- Add `Crygen::Enums::PropScope` enum.
- Add `scope` optional argument to `add_property` overloaded methods. 

## Issue reference
Setup the property scope : #6