### PR TITLE
Rename file name for the `Crygen::Abstract::GeneratorInterface` interface.

### DIFF
--- a/src/interfaces/generator.cr
+++ b/src/interfaces/generator.cr
@@ -1,5 +1,0 @@
-# Classes located in the `src/types` folder must always have a public method named `generate`.
-abstract class Crygen::Abstract::GeneratorInterface
-  # This method generates a class.
-  abstract def generate : String
-end

--- a/src/interfaces/generator_interface.cr
+++ b/src/interfaces/generator_interface.cr
@@ -1,0 +1,7 @@
+# The `Crygen::Abstract::GeneratorInterface` is an interface with a method signature : `generate`.
+# This latter must return a string to easily get the generated code.
+# This rule is applied to classes located in the `src/types` directory.
+abstract class Crygen::Abstract::GeneratorInterface
+  # This method generates a class.
+  abstract def generate : String
+end

--- a/src/types/annotation.cr
+++ b/src/types/annotation.cr
@@ -1,5 +1,5 @@
 require "./../modules/arg"
-require "./../interfaces/generator"
+require "./../interfaces/generator_interface"
 
 # A class that allows to generate an annotation.
 # ```

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -1,5 +1,5 @@
 require "./../modules/*"
-require "./../interfaces/generator"
+require "./../interfaces/generator_interface"
 
 # A class that generates a class.
 # ```

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -1,5 +1,5 @@
 require "./../modules/method.cr"
-require "./../interfaces/generator"
+require "./../interfaces/generator_interface"
 
 # A class that generates an enumeration (enum).
 # ```

--- a/src/types/libc.cr
+++ b/src/types/libc.cr
@@ -1,5 +1,5 @@
-require "./../interfaces/generator"
 require "./../types/*"
+require "./../interfaces/generator_interface"
 
 # A class that generates a C library.
 # ```

--- a/src/types/macro.cr
+++ b/src/types/macro.cr
@@ -1,5 +1,5 @@
-require "./../interfaces/generator"
 require "./../modules/arg"
+require "./../interfaces/generator_interface"
 
 # A class that generates a macro
 # ```

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -1,5 +1,5 @@
 require "./../modules/*"
-require "./../interfaces/generator"
+require "./../interfaces/generator_interface"
 
 # A class that generates a method.
 # ```

--- a/src/types/module.cr
+++ b/src/types/module.cr
@@ -1,6 +1,6 @@
-require "./../interfaces/generator"
-require "./../modules/*"
 require "./../types/*"
+require "./../modules/*"
+require "./../interfaces/generator_interface"
 
 # A class thar generates a module.
 # A module can include any objects, like classes, structs, enums and modules itselves.

--- a/src/types/struct.cr
+++ b/src/types/struct.cr
@@ -1,5 +1,5 @@
 require "./../modules/*"
-require "./../interfaces/generator"
+require "./../interfaces/generator_interface"
 
 # A class that generates a struct.
 # ```


### PR DESCRIPTION
> [!NOTE]
> If this PR is intended to resolve an issue, please indicate the issue number.

## Description
These changes rename the `generator.cr` file to `generator_interface.cr` to explicity indicate that it's an interface.

## Changelog
- Rename file to `generator_interface.cr` file for the `Crygen::Abstract::GeneratorInterface` interface.

