### PR TITLE
Add nullable properties

### DIFF
--- a/spec/class/class_spec.cr
+++ b/spec/class/class_spec.cr
@@ -121,17 +121,39 @@ describe Crygen::Types::Class do
     CRYSTAL
   end
 
-  it "creates a class with scoped properties" do
+  it "creates a class with nilable properties" do
     class_type = test_person_class()
-    class_type.add_property(:property, "full_name", "String")
-    class_type.add_property(:getter, "first_name", "String", :protected)
-    class_type.add_property(:setter, "last_name", "String", :private)
+    class_type.add_property(CGE::PropVisibility::NilProperty, "last_name", "String")
+    class_type.add_property(CGE::PropVisibility::NilGetter, "first_name", "String")
 
     class_type.generate.should eq(<<-CRYSTAL)
     class Person
-      property full_name : String
-      protected getter first_name : String
-      private setter last_name : String
+      property? last_name : String
+      getter? first_name : String
+    end
+    CRYSTAL
+
+    class_type = test_person_class()
+    class_type.add_property(:nil_property, "last_name", "String")
+    class_type.add_property(:nil_getter, "first_name", "String")
+
+    class_type.generate.should eq(<<-CRYSTAL)
+    class Person
+      property? last_name : String
+      getter? first_name : String
+    end
+    CRYSTAL
+  end
+
+  it "creates a class with nilable scoped properties" do
+    class_type = test_person_class()
+    class_type.add_property(:nil_property, "last_name", "String", :private)
+    class_type.add_property(:nil_getter, "first_name", "String", :protected)
+
+    class_type.generate.should eq(<<-CRYSTAL)
+    class Person
+      private property? last_name : String
+      protected getter? first_name : String
     end
     CRYSTAL
   end

--- a/spec/struct/struct_spec.cr
+++ b/spec/struct/struct_spec.cr
@@ -156,7 +156,6 @@ describe Crygen::Types::Struct do
     CRYSTAL
   end
 
-
   it "creates a class with nilable scoped properties" do
     struct_type = test_point_struct()
     struct_type.add_property(:nil_property, "x", "Int32", :private)

--- a/spec/struct/struct_spec.cr
+++ b/spec/struct/struct_spec.cr
@@ -117,6 +117,30 @@ describe Crygen::Types::Struct do
     CRYSTAL
   end
 
+  it "creates a struct with nilable properties" do
+    struct_type = test_point_struct()
+    struct_type.add_property(CGE::PropVisibility::NilProperty, "x", "Int32")
+    struct_type.add_property(CGE::PropVisibility::NilGetter, "y", "Int32")
+
+    struct_type.generate.should eq(<<-CRYSTAL)
+    struct Point
+      property? x : Int32
+      getter? y : Int32
+    end
+    CRYSTAL
+
+    struct_type = test_point_struct()
+    struct_type.add_property(:nil_property, "x", "Int32")
+    struct_type.add_property(:nil_getter, "y", "Int32")
+
+    struct_type.generate.should eq(<<-CRYSTAL)
+    struct Point
+      property? x : Int32
+      getter? y : Int32
+    end
+    CRYSTAL
+  end
+
   it "creates a struct with scoped properties" do
     struct_type = test_point_struct()
     struct_type.add_property(:property, "x", "Int32")
@@ -128,6 +152,20 @@ describe Crygen::Types::Struct do
       property x : Int32
       protected getter y : Int32
       private setter z : Int32
+    end
+    CRYSTAL
+  end
+
+
+  it "creates a class with nilable scoped properties" do
+    struct_type = test_point_struct()
+    struct_type.add_property(:nil_property, "x", "Int32", :private)
+    struct_type.add_property(:nil_getter, "y", "Int32", :protected)
+
+    struct_type.generate.should eq(<<-CRYSTAL)
+    struct Point
+      private property? x : Int32
+      protected getter? y : Int32
     end
     CRYSTAL
   end

--- a/src/enums/prop_visibility.cr
+++ b/src/enums/prop_visibility.cr
@@ -2,6 +2,8 @@
 @[Flags]
 enum Crygen::Enums::PropVisibility
   Getter
+  NilGetter
   Property
+  NilProperty
   Setter
 end

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -80,9 +80,9 @@ module Crygen::Modules::Property
   # Returns: String
   private def string_visibility(visibility : Crygen::Enums::PropVisibility) : String
     case visibility
-      when .nil_getter? then "getter?"
-      when .nil_property? then "property?"
-      else visibility.to_s.downcase
+    when .nil_getter?   then "getter?"
+    when .nil_property? then "property?"
+    else                     visibility.to_s.downcase
     end
   end
 end

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -13,7 +13,7 @@ module Crygen::Modules::Property
   # Returns:
   # an object class itself.
   def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String) : self
-    @properties << {:scope => "public", :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => nil}
+    @properties << {:scope => "public", :visibility => string_visibility(visibility), :name => name, :type => type, :value => nil}
     self
   end
 
@@ -26,7 +26,7 @@ module Crygen::Modules::Property
   # Returns:
   # an object class itself.
   def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, scope : Crygen::Enums::PropScope = :public) : self
-    @properties << {:scope => scope.to_s.downcase, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => nil}
+    @properties << {:scope => scope.to_s.downcase, :visibility => string_visibility(visibility), :name => name, :type => type, :value => nil}
     self
   end
 
@@ -39,7 +39,7 @@ module Crygen::Modules::Property
   # Returns:
   # an object class itself.
   def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, value : String) : self
-    @properties << {:scope => "public", :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => value}
+    @properties << {:scope => "public", :visibility => string_visibility(visibility), :name => name, :type => type, :value => value}
     self
   end
 
@@ -53,7 +53,7 @@ module Crygen::Modules::Property
   # Returns:
   # an object class itself.
   def add_property(visibility : Crygen::Enums::PropVisibility, name : String, type : String, value : String, scope : Crygen::Enums::PropScope = :public) : self
-    @properties << {:scope => scope.to_s.downcase, :visibility => visibility.to_s.downcase, :name => name, :type => type, :value => value}
+    @properties << {:scope => scope.to_s.downcase, :visibility => string_visibility(visibility), :name => name, :type => type, :value => value}
     self
   end
 
@@ -71,6 +71,18 @@ module Crygen::Modules::Property
         str << " = #{prop[:value]}" if prop[:value]
         str << "\n"
       end
+    end
+  end
+
+  # Gets the property visibility.
+  # Parameters:
+  # - visibility : Crygen::Enums::PropVisibility
+  # Returns: String
+  private def string_visibility(visibility : Crygen::Enums::PropVisibility) : String
+    case visibility
+      when .nil_getter? then "getter?"
+      when .nil_property? then "property?"
+      else visibility.to_s.downcase
     end
   end
 end


### PR DESCRIPTION
> [!NOTE]
> If this PR is intended to resolve an issue, please indicate the issue reference.

## Description
These changes add two new cases : `NilGetter` and `NilProperty` in the `Crygen::Enums::PropVisibility` enum.

## Changelog
- Add nullable properties : `NilGetter` and `NilProperty`.

## Issue reference
Add a module for annotations: #11