### PR TITLE
Add the `Crygen::Modules::Annotation` module.

### DIFF
--- a/src/modules/annotation.cr
+++ b/src/modules/annotation.cr
@@ -1,0 +1,25 @@
+# Module that is used to store and add the annotations.
+module Crygen::Modules::Annotation
+  @annotations = [] of Crygen::Types::Annotation
+
+  # Adds annotation(s) onto object.
+  # Example:
+  # ```
+  # class_type = CGT::Class.new("Person")
+  # class_type.add_annotation(CGT::Annotation.new("Experimental"))
+  # class_type.add_annotation(CGT::Annotation.new("AnotherAnnotation"))
+  # ```
+  # Output:
+  # ```
+  # @[Experimental]
+  # @[AnotherAnnotation]
+  # class Person
+  # end
+  # ```
+  # Returns:
+  # an object class itself.
+  def add_annotation(annotation_type : Crygen::Types::Annotation) : self
+    @annotations << annotation_type
+    self
+  end
+end

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -24,32 +24,11 @@ class Crygen::Types::Class < Crygen::Abstract::GeneratorInterface
   include Crygen::Modules::InstanceVar
   include Crygen::Modules::ClassVar
   include Crygen::Modules::Method
+  include Crygen::Modules::Annotation
 
   @type : Symbol = :normal
-  @annotations = [] of Crygen::Types::Annotation
 
-  def initialize(@name : String)
-  end
-
-  # Adds annotation(s) on a class.
-  # ```
-  # class_type = CGT::Class.new("Person")
-  # class_type.add_annotation(CGT::Annotation.new("Experimental"))
-  # class_type.add_annotation(CGT::Annotation.new("AnotherAnnotation"))
-  # ```
-  # Output:
-  # ```
-  # @[Experimental]
-  # @[AnotherAnnotation]
-  # class Person
-  # end
-  # ```
-  # Returns:
-  # an object class itself.
-  def add_annotation(annotation_type : Crygen::Types::Annotation) : self
-    @annotations << annotation_type
-    self
-  end
+  def initialize(@name : String); end
 
   # Set as an abstract class.
   # ```

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -17,13 +17,12 @@ class Crygen::Types::Method < Crygen::Abstract::GeneratorInterface
   include Crygen::Modules::Comment
   include Crygen::Modules::Scope
   include Crygen::Modules::Arg
+  include Crygen::Modules::Annotation
 
   # Body content.
   @body : String = ""
 
-  def initialize(@name : String, @return_type : String)
-    @annotations = [] of Crygen::Types::Annotation
-  end
+  def initialize(@name : String, @return_type : String); end
 
   # Adds an annotation on a class.
   # ```

--- a/src/types/struct.cr
+++ b/src/types/struct.cr
@@ -24,30 +24,9 @@ class Crygen::Types::Struct < Crygen::Abstract::GeneratorInterface
   include Crygen::Modules::InstanceVar
   include Crygen::Modules::ClassVar
   include Crygen::Modules::Method
-
-  @annotations = [] of Crygen::Types::Annotation
+  include Crygen::Modules::Annotation
 
   def initialize(@name : String); end
-
-  # Adds an annotation onto a class.
-  # ```
-  # struct_type = CGT::Struct.new("Point")
-  # struct_type.add_annotation(CGT::Annotation.new("Experimental"))
-  # ```
-  # Output:
-  # ```
-  # @[Experimental]
-  # struct Point
-  # end
-  # ```
-  # Parameters:
-  # - annotation_type : Crygen::Types::Annotation
-  # Returns:
-  # an object class itself.
-  def add_annotation(annotation_type : Crygen::Types::Annotation) : self
-    @annotations << annotation_type
-    self
-  end
 
   # Generates a struct.
   # Returns: String


### PR DESCRIPTION
> [!NOTE]
> If this PR is intended to resolve an issue, please indicate the issue reference.

## Description
These changes adds a `Crygen::Modules::Annotation` module that enables to store and add the annotations. Repetitive code is deleted.

## Changelog
- Add the Crygen::Modules::Annotation module.

## Issue reference
Add a module for annotations: #11
