### PR TITLE
Delete redudant params and returns

### DIFF
--- a/src/modules/annotation.cr
+++ b/src/modules/annotation.cr
@@ -16,8 +16,6 @@ module Crygen::Modules::Annotation
   # class Person
   # end
   # ```
-  # Returns:
-  # an object class itself.
   def add_annotation(annotation_type : Crygen::Types::Annotation) : self
     @annotations << annotation_type
     self

--- a/src/modules/arg.cr
+++ b/src/modules/arg.cr
@@ -3,30 +3,18 @@ module Crygen::Modules::Arg
   @args = [] of Tuple(String, String, String | Nil)
 
   # Add an argument with no default value.
-  # Parameters:
-  # - name : String
-  # - type : String
-  # Returns:
-  # an object class itself.
   def add_arg(name : String, type : String) : self
     @args << {name, type, nil}
     self
   end
 
   # Add an argument with default value.
-  # Parameters:
-  # - name : String
-  # - type : String
-  # - value : String
-  # Returns:
-  # an object class itself.
   def add_arg(name : String, type : String, value : String) : self
     @args << {name, type, value}
     self
   end
 
   # Generate the args.
-  # Returns: String.
   def generate_args : String
     String.build do |str|
       str << '(' unless @args.empty?

--- a/src/modules/class_var.cr
+++ b/src/modules/class_var.cr
@@ -3,23 +3,12 @@ module Crygen::Modules::ClassVar
   @class_vars = [] of Tuple(String, String, String | Nil)
 
   # Adds a class var with no default value.
-  # Parameters:
-  # - name : String
-  # - type : String
-  # Returns:
-  # an object class itself.
   def add_class_var(name : String, type : String) : self
     @class_vars << {name, type, nil}
     self
   end
 
   # Adds a class var with default value.
-  # Parameters:
-  # - name : String
-  # - type : String
-  # - value : String
-  # Returns:
-  # an object class itself.
   def add_class_var(name : String, type : String, value : String) : self
     if type == "String"
       @class_vars << {name, type, value.dump}
@@ -30,7 +19,6 @@ module Crygen::Modules::ClassVar
   end
 
   # Generate the class_vars.
-  # Returns: String.
   def generate_class_vars : String
     String.build do |str|
       @class_vars.each do |instance_var|

--- a/src/modules/comment.cr
+++ b/src/modules/comment.cr
@@ -3,10 +3,6 @@ module Crygen::Modules::Comment
   @comments = [] of String
 
   # Add a line or a multiline comment.
-  # Parameters:
-  # - value : String
-  # Returns:
-  # an object class itself.
   def add_comment(value : String) : self
     value.each_line do |line|
       @comments << line

--- a/src/modules/instance_var.cr
+++ b/src/modules/instance_var.cr
@@ -3,23 +3,12 @@ module Crygen::Modules::InstanceVar
   @instance_vars = [] of Tuple(String, String, String | Nil)
 
   # Add an argument with no default value.
-  # Parameters:
-  # - name : String
-  # - type : String
-  # Returns:
-  # an object class itself.
   def add_instance_var(name : String, type : String) : self
     @instance_vars << {name, type, nil}
     self
   end
 
   # Add an argument with default value.
-  # Parameters:
-  # - name : String
-  # - type : String
-  # - value : String
-  # Returns:
-  # an object class itself.
   def add_instance_var(name : String, type : String, value : String) : self
     if type == "String"
       @instance_vars << {name, type, value.dump}
@@ -30,7 +19,6 @@ module Crygen::Modules::InstanceVar
   end
 
   # Generate the instance vars.
-  # Returns: String.
   def generate_instance_vars : String
     String.build do |str|
       @instance_vars.each do |instance_var|

--- a/src/modules/method.cr
+++ b/src/modules/method.cr
@@ -4,10 +4,6 @@ module Crygen::Modules::Method
   @methods = [] of Crygen::Types::Method
 
   # Adds an method into class.
-  # Parameters:
-  # method : Crygen::Types::Method
-  # Returns:
-  # an object class itself.
   def add_method(method : Crygen::Types::Method) : self
     @methods << method
     self

--- a/src/modules/mixin.cr
+++ b/src/modules/mixin.cr
@@ -9,7 +9,7 @@ module Crygen::Modules::Mixin
     self
   end
 
-  # Adds an extend into object
+  # Adds an extend into object.
   def add_extend(name : String) : self
     @extends << name
     self

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -6,14 +6,6 @@ module Crygen::Modules::Property
   @properties = [] of Hash(Symbol, String | Nil)
 
   # Adds a property into object (visibility, name, type, value and scope).
-  # Parameters:
-  # - visibility : Crygen::Enums::PropVisibility
-  # - name : String
-  # - type : String
-  # - value : String
-  # - scope : Crygen::Enums::PropScope = :public
-  # Returns:
-  # an object class itself.
   def add_property(
     visibility : Crygen::Enums::PropVisibility,
     name : String,
@@ -35,7 +27,6 @@ module Crygen::Modules::Property
   end
 
   # Generates the properties.
-  # Returns: String
   protected def generate_properties : String
     String.build do |str|
       @properties.each do |prop|
@@ -55,9 +46,6 @@ module Crygen::Modules::Property
   end
 
   # Gets the property visibility.
-  # Parameters:
-  # - visibility : Crygen::Enums::PropVisibility
-  # Returns: String
   private def string_visibility(visibility : Crygen::Enums::PropVisibility) : String
     case visibility
     when .nil_getter?   then "getter?"

--- a/src/modules/scope.cr
+++ b/src/modules/scope.cr
@@ -2,16 +2,12 @@ module Crygen::Modules::Scope
   @scope : Symbol = :public
 
   # Set the scope as protected.
-  # Returns:
-  # an object class itself.
   def as_protected : self
     @scope = :protected
     self
   end
 
   # Set the scope as private.
-  # Returns:
-  # an object class itself.
   def as_private : self
     @scope = :private
     self

--- a/src/types/alias.cr
+++ b/src/types/alias.cr
@@ -4,8 +4,7 @@ require "./../interfaces/generator_interface"
 class Crygen::Types::Alias < Crygen::Abstract::GeneratorInterface
   include Crygen::Modules::Comment
 
-  def initialize(@name : String, @types : Array(String))
-  end
+  def initialize(@name : String, @types : Array(String)); end
 
   def generate : String
     String.build do |str|

--- a/src/types/annotation.cr
+++ b/src/types/annotation.cr
@@ -27,8 +27,6 @@ class Crygen::Types::Annotation < Crygen::Abstract::GeneratorInterface
   # ```
   # @[MyAnnotation(true)]
   # ```
-  # Returns:
-  # an object class itself.
   def add_arg(value : String) : self
     @args << {nil, value}
     self
@@ -43,15 +41,12 @@ class Crygen::Types::Annotation < Crygen::Abstract::GeneratorInterface
   # ```
   # @[MyAnnotation(full_name: "John Doe")]
   # ```
-  # Returns:
-  # an object class itself.
   def add_arg(name : String, value : String) : self
     @args << {name, value}
     self
   end
 
   # Generates an annotation.
-  # Returns: String
   def generate : String
     String.build do |str|
       str << "@[#{@name}"
@@ -61,7 +56,6 @@ class Crygen::Types::Annotation < Crygen::Abstract::GeneratorInterface
   end
 
   # Generates args for an annotation.
-  # Returns: String
   private def generate_args : String
     String.build do |str|
       str << '(' unless @args.empty?

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -41,15 +41,12 @@ class Crygen::Types::Class < Crygen::Abstract::GeneratorInterface
   # abstract class Person
   # end
   # ```
-  # Returns:
-  # an object class itself.
   def as_abstract : self
     @type = :abstract
     self
   end
 
   # Generates a Crystal code.
-  # Returns: String
   def generate : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -37,8 +37,6 @@ class Crygen::Types::Enum
   #   Employee
   # end
   # ```
-  # Returns:
-  # an object class itself.
   def add_constant(name : String) : self
     @constants << {name, nil}
     self
@@ -49,15 +47,12 @@ class Crygen::Types::Enum
   # enum_type = Crygen::Types::Enum.new("Person")
   # enum_type.add_constant("Employee", 1)
   # ```
-  # Returns:
-  # an object class itself.
   def add_constant(name : String, value : String) : self
     @constants << {name, value}
     self
   end
 
   # Generates an enum.
-  # Returns: String
   def generate : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }

--- a/src/types/libc.cr
+++ b/src/types/libc.cr
@@ -32,8 +32,6 @@ class Crygen::Types::LibC < Crygen::Abstract::GeneratorInterface
   #   fun getch(arg1 : Int32, arg2 : Int32) : Int32
   # end
   # ```
-  # Returns:
-  # an object class itself.
   def add_function(name : String, return_type : String, args : Array(Tuple(String, String)) | Nil = nil) : self
     @functions << {
       :name        => name,
@@ -57,8 +55,6 @@ class Crygen::Types::LibC < Crygen::Abstract::GeneratorInterface
   #   end
   # end
   # ```
-  # Returns:
-  # an object class itself.
   def add_struct(name : String, fields : FieldArray) : self
     @objects << {name, :struct, fields}
     self
@@ -78,15 +74,12 @@ class Crygen::Types::LibC < Crygen::Abstract::GeneratorInterface
   #   end
   # end
   # ```
-  # Returns:
-  # an object class itself.
   def add_union(name : String, fields : FieldArray) : self
     @objects << {name, :union, fields}
     self
   end
 
   # Generates a C lib.
-  # Returns: String
   def generate : String
     String.build do |str|
       str << "lib #{@name}\n"
@@ -113,9 +106,6 @@ class Crygen::Types::LibC < Crygen::Abstract::GeneratorInterface
   end
 
   # Generate the args.
-  # Parameters:
-  # - args : Array(Tuple(String, String))
-  # Returns: String
   private def generate_args(args : Array(Tuple(String, String))) : String
     String.build do |str|
       str << '('

--- a/src/types/macro.cr
+++ b/src/types/macro.cr
@@ -29,10 +29,6 @@ class Crygen::Types::Macro < Crygen::Abstract::GeneratorInterface
   # macro example(name)
   # end
   # ```
-  # Parameters:
-  # - arg : String
-  # Returns:
-  # an object class itself.
   def add_arg(arg : String) : self
     @args << arg
     self
@@ -50,10 +46,6 @@ class Crygen::Types::Macro < Crygen::Abstract::GeneratorInterface
   #   puts {{ name }}
   # end
   # ```
-  # Parameters:
-  # - line : String
-  # Returns:
-  # an object class itself.
   def add_body(line : String) : self
     @body += line + "\n"
     self
@@ -71,17 +63,12 @@ class Crygen::Types::Macro < Crygen::Abstract::GeneratorInterface
   #   puts {{ name }}
   # end
   # ```
-  # Parameters:
-  # - body : String
-  # Returns:
-  # an object class itself.
   def body=(body : String) : self
     @body = body
     self
   end
 
   # Generates the macro.
-  # Returns: String
   def generate : String
     String.build do |str|
       str << "macro #{@name}"
@@ -93,7 +80,6 @@ class Crygen::Types::Macro < Crygen::Abstract::GeneratorInterface
   end
 
   # Generate the args.
-  # Returns: String
   private def generate_args : String
     String.build do |str|
       str << '(' unless @args.empty?

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -35,10 +35,6 @@ class Crygen::Types::Method < Crygen::Abstract::GeneratorInterface
   # def full_name : String
   # end
   # ```
-  # Parameters:
-  # - annotation_type : Crygen::Types::Annotation
-  # Returns:
-  # an object class itself.
   def add_annotation(annotation_type : Crygen::Types::Annotation) : self
     @annotations << annotation_type
     self
@@ -55,17 +51,12 @@ class Crygen::Types::Method < Crygen::Abstract::GeneratorInterface
   #   "Hello world"
   # end
   # ```
-  # Parameters:
-  # - body : String
-  # Returns:
-  # an object class itself.
   def add_body(body : String) : self
     @body += body
     self
   end
 
   # Generates the methods.
-  # Returns: String
   def generate : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }
@@ -78,7 +69,6 @@ class Crygen::Types::Method < Crygen::Abstract::GeneratorInterface
   end
 
   # Generates the abstract methods.
-  # Returns: String
   protected def generate_abstract_method : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }

--- a/src/types/module.cr
+++ b/src/types/module.cr
@@ -50,17 +50,12 @@ class Crygen::Types::Module < Crygen::Abstract::GeneratorInterface
   #   end
   # end
   # ```
-  # Parameters:
-  # - object_type : ObjectType
-  # Returns:
-  # an object class itself.
   def add_object(object_type : ObjectType) : self
     @objects << object_type
     self
   end
 
   # Generates a module.
-  # Returns: String
   def generate : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }

--- a/src/types/struct.cr
+++ b/src/types/struct.cr
@@ -29,7 +29,6 @@ class Crygen::Types::Struct < Crygen::Abstract::GeneratorInterface
   def initialize(@name : String); end
 
   # Generates a struct.
-  # Returns: String
   def generate : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }


### PR DESCRIPTION
## Description
Whereas parameters and return values are already specified in the code. These two will be removed from the comments for simplicity.
