### PR TITLE
Add `pull` cmd and `cruml` dependency. Ignore `/out` directory.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
+/bin/
 /docs/
 /lib/
-/bin/
+/out/
 /.shards/
 *.dwarf
 

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -7,3 +7,5 @@ tasks:
       - bin/ameba
   test:
     cmd: crystal spec -p
+  pull:
+    cmd: git pull origin main --ff-only

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -8,4 +8,4 @@ tasks:
   test:
     cmd: crystal spec -p
   pull:
-    cmd: git pull origin main --ff-only
+    cmd: git pull origin main --rebase

--- a/shard.yml
+++ b/shard.yml
@@ -10,8 +10,9 @@ development_dependencies:
   ameba:
     github: crystal-ameba/ameba
     version: ~> 1.6.0
-  # cruml:
-  #   github: tamdaz/cruml
+  cruml:
+    github: tamdaz/cruml
+    branch: main
 
 targets:
   console:


### PR DESCRIPTION
## Description

Added a `pull` command to get changes easier. Cruml dependency is added in `development_dependencies`. The `/out/` directory _(which is used to save the diagram classes)_ is ignored.