### PR TITLE
Add docs and example for alias.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ library : [nette/php-generator](https://github.com/nette/php-generator).
   - [Annotation](#annotation)
   - [Struct](#struct)
   - [Module](#module)
+  - [Alias](#alias)
 - [Usage](#usage)
 - [Todos](#todos)
 - [Lib C-binding](#lib-c-binding)
@@ -427,6 +428,19 @@ macro example(name, value)
     puts {{ "Hello world" }}
   {% end %}
 end
+```
+
+## Alias
+
+```
+alias_type = CGT::Alias.new("MyAlias", %w[Foo Bar])
+puts alias_type.generate
+```
+
+Output:
+
+```
+alias MyAlias = Foo | Bar
 ```
 
 ## Usage

--- a/src/types/alias.cr
+++ b/src/types/alias.cr
@@ -19,9 +19,7 @@ class Crygen::Types::Alias < Crygen::Abstract::GeneratorInterface
   def generate : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }
-      str << "alias "
-      str << @name
-      str << " = "
+      str << "alias " << @name << " = "
       types_count = @types.size
       @types.each_with_index do |type, idx|
         str << type

--- a/src/types/alias.cr
+++ b/src/types/alias.cr
@@ -1,11 +1,21 @@
 require "./../modules/*"
 require "./../interfaces/generator_interface"
 
+# Class that is used to generate the aliases.
+# ```
+# alias_type = CGT::Alias.new("MyAlias", %w[Foo Bar])
+# puts alias_type.generate
+# ```
+# Output:
+# ```
+# alias MyAlias = Foo | Bar
+# ```
 class Crygen::Types::Alias < Crygen::Abstract::GeneratorInterface
   include Crygen::Modules::Comment
 
   def initialize(@name : String, @types : Array(String)); end
 
+  # Generates an alias.
   def generate : String
     String.build do |str|
       @comments.each { |comment| str << "# #{comment}\n" }


### PR DESCRIPTION
## Description
Following PR #19, the documentation for the alias is added and the example of use is added in the README to better understand how to use it.

## PR reference(s)
#19 Add aliases, mixins, simplify `add_property`, fix bugs