### PR TITLE
`Crygen::Types::Enum` implments Crygen::Abstract::GeneratorInterface

### DIFF
--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -17,7 +17,7 @@ require "./../interfaces/generator_interface"
 #   Intern
 # end
 # ```
-class Crygen::Types::Enum
+class Crygen::Types::Enum < Crygen::Abstract::GeneratorInterface
   include Crygen::Modules::Comment
   include Crygen::Modules::Method
   include Crygen::Modules::Annotation


### PR DESCRIPTION
## Description

This PR provides a change where the `CGT::Enum` class did not implement the `Crygen::Abstract::GeneratorInterface` interface.
