### PR TITLE
Rename interface to `Crygen::Interfaces::GeneratorInterface`

### DIFF
--- a/src/console.cr
+++ b/src/console.cr
@@ -30,7 +30,7 @@ end
 def make_type(class_name : String) : Nil
   method_generate = CGT::Method.new("generate", "String")
   method_generate.add_body("# Put the code...")
-  class_type = CGT::Class.new("Crygen::Types::#{class_name} < Crygen::Abstract::GeneratorInterface")
+  class_type = CGT::Class.new("Crygen::Types::#{class_name} < Crygen::Interfaces::GeneratorInterface")
   class_type.add_comment("TODO : Write the documentation about the `#{class_name}` class.")
   class_type.add_method(method_generate)
 

--- a/src/interfaces/generator_interface.cr
+++ b/src/interfaces/generator_interface.cr
@@ -1,7 +1,7 @@
-# The `Crygen::Abstract::GeneratorInterface` is an interface with a method signature : `generate`.
+# The `Crygen::Interfaces::GeneratorInterface` is an interface with a method signature : `generate`.
 # This latter must return a string to easily get the generated code.
 # This rule is applied to classes located in the `src/types` directory.
-abstract class Crygen::Abstract::GeneratorInterface
+abstract class Crygen::Interfaces::GeneratorInterface
   # This method is used to generates an object.
   abstract def generate : String
 end

--- a/src/types/alias.cr
+++ b/src/types/alias.cr
@@ -10,7 +10,7 @@ require "./../interfaces/generator_interface"
 # ```
 # alias MyAlias = Foo | Bar
 # ```
-class Crygen::Types::Alias < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Alias < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Comment
 
   def initialize(@name : String, @types : Array(String)); end

--- a/src/types/annotation.cr
+++ b/src/types/annotation.cr
@@ -13,7 +13,7 @@ require "./../interfaces/generator_interface"
 # class Person
 # end
 # ```
-class Crygen::Types::Annotation < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Annotation < Crygen::Interfaces::GeneratorInterface
   @args = [] of Tuple(String | Nil, String)
 
   def initialize(@name : String); end

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -18,7 +18,7 @@ require "./../interfaces/generator_interface"
 #   end
 # end
 # ```
-class Crygen::Types::Class < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Class < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Comment
   include Crygen::Modules::Property
   include Crygen::Modules::InstanceVar

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -17,7 +17,7 @@ require "./../interfaces/generator_interface"
 #   Intern
 # end
 # ```
-class Crygen::Types::Enum < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Enum < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Comment
   include Crygen::Modules::Method
   include Crygen::Modules::Annotation

--- a/src/types/libc.cr
+++ b/src/types/libc.cr
@@ -13,7 +13,7 @@ require "./../interfaces/generator_interface"
 #   fun getch : Int32
 # end
 # ```
-class Crygen::Types::LibC < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::LibC < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Annotation
 
   alias FieldArray = Array(Tuple(String, String))

--- a/src/types/macro.cr
+++ b/src/types/macro.cr
@@ -13,7 +13,7 @@ require "./../interfaces/generator_interface"
 #   puts {{ name }}
 # end
 # ```
-class Crygen::Types::Macro < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Macro < Crygen::Interfaces::GeneratorInterface
   @args = [] of String
   @body = ""
 

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -13,7 +13,7 @@ require "./../interfaces/generator_interface"
 #   "Hello world"
 # end
 # ```
-class Crygen::Types::Method < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Comment
   include Crygen::Modules::Scope
   include Crygen::Modules::Arg

--- a/src/types/module.cr
+++ b/src/types/module.cr
@@ -22,7 +22,7 @@ require "./../interfaces/generator_interface"
 #   end
 # end
 # ```
-class Crygen::Types::Module < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Module < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Comment
 
   alias ObjectType = Crygen::Types::Module | Crygen::Types::Class | Crygen::Types::Struct | Crygen::Types::Enum

--- a/src/types/struct.cr
+++ b/src/types/struct.cr
@@ -18,7 +18,7 @@ require "./../interfaces/generator_interface"
 #   end
 # end
 # ```
-class Crygen::Types::Struct < Crygen::Abstract::GeneratorInterface
+class Crygen::Types::Struct < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Comment
   include Crygen::Modules::Property
   include Crygen::Modules::InstanceVar


### PR DESCRIPTION
## Description

To make the naming of the interface more consistent, this latter has been named to `Crygen::Interfaces::GeneratorInterface`.