### PR TITLE
Disable the `Documentation/DocumentationAdmonition` rule.

### DIFF
--- a/.ameba.yml
+++ b/.ameba.yml
@@ -1,0 +1,2 @@
+Documentation/DocumentationAdmonition:
+  Enabled: false


### PR DESCRIPTION
## Description

The `Documentation/DocumentationAdmonition` rule is deactivated to allow a `TODO`, `FIXME` reminder followed by a comment.