### PR TITLE
Breaking change: Annotation helpers

### DIFF
--- a/spec/annotation_spec.cr
+++ b/spec/annotation_spec.cr
@@ -40,48 +40,72 @@ describe Crygen::Types::Annotation do
   end
 
   describe "annotation helpers" do
-    it "#as_deprecated" do
-      Crygen::Types::Class.new("AnnotationTest").as_deprecated.generate.should eq(<<-CRYSTAL)
+    it "#deprecated" do
+      Crygen::Types::Class.new("AnnotationTest").deprecated.generate.should eq(<<-CRYSTAL)
       @[Deprecated]
       class AnnotationTest
       end
       CRYSTAL
 
-      Crygen::Types::Class.new("AnnotationTest").as_deprecated("Use something instead").generate.should eq(<<-CRYSTAL)
+      Crygen::Types::Class.new("AnnotationTest").deprecated("Use something instead").generate.should eq(<<-CRYSTAL)
       @[Deprecated("Use something instead")]
       class AnnotationTest
       end
       CRYSTAL
     end
 
-    it "#as_experimental" do
-      Crygen::Types::Class.new("AnnotationTest").as_experimental.generate.should eq(<<-CRYSTAL)
+    it "#experimental" do
+      Crygen::Types::Class.new("AnnotationTest").experimental.generate.should eq(<<-CRYSTAL)
       @[Experimental]
       class AnnotationTest
       end
       CRYSTAL
 
-      Crygen::Types::Class.new("AnnotationTest").as_experimental("Lorem ipsum").generate.should eq(<<-CRYSTAL)
+      Crygen::Types::Class.new("AnnotationTest").experimental("Lorem ipsum").generate.should eq(<<-CRYSTAL)
       @[Experimental("Lorem ipsum")]
       class AnnotationTest
       end
       CRYSTAL
     end
 
-    it "#as_flags" do
-      Crygen::Types::Enum.new("AnnotationTest").as_flags.generate.should eq(<<-CRYSTAL)
+    it "#flags" do
+      Crygen::Types::Enum.new("AnnotationTest").flags.generate.should eq(<<-CRYSTAL)
       @[Flags]
       enum AnnotationTest
       end
       CRYSTAL
     end
 
-    it "#as_link" do
-      Crygen::Types::LibC.new("AnnotationTest").add_link("musl").generate.should eq(<<-CRYSTAL)
+    it "#link" do
+      Crygen::Types::LibC.new("AnnotationTest").link("musl").generate.should eq(<<-CRYSTAL)
       @[Link("musl")]
       lib AnnotationTest
       end
       CRYSTAL
+    end
+
+    it "#thread_local" do
+      # FIXME: Complete the @[ThreadLocal] annotation spec.
+    end
+
+    it "#always_inline" do
+      Crygen::Types::Method.new("always_inline", "Void").always_inline.generate.should eq(<<-CRYSTAL)
+      @[AlwaysInline]
+      def always_inline : Void
+      end
+      CRYSTAL
+    end
+
+    it "#no_inline" do
+      Crygen::Types::Method.new("no_inline", "Void").no_inline.generate.should eq(<<-CRYSTAL)
+      @[NoInline]
+      def no_inline : Void
+      end
+      CRYSTAL
+    end
+
+    it "#call_convention" do
+      # FIXME: Complete the @[CallConvention] annotation spec.
     end
   end
 end

--- a/spec/class/class_spec.cr
+++ b/spec/class/class_spec.cr
@@ -19,14 +19,14 @@ describe Crygen::Types::Class do
   end
 
   it "creates a class with helpers" do
-    class_type = test_person_class().as_deprecated("This class is deprecated.")
+    class_type = test_person_class().deprecated("This class is deprecated.")
     class_type.generate.should eq(<<-CRYSTAL)
     @[Deprecated("This class is deprecated.")]
     class Person
     end
     CRYSTAL
 
-    class_type = test_person_class().as_experimental("This class is experimental.")
+    class_type = test_person_class().experimental("This class is experimental.")
     class_type.generate.should eq(<<-CRYSTAL)
     @[Experimental("This class is experimental.")]
     class Person

--- a/spec/enum_spec.cr
+++ b/spec/enum_spec.cr
@@ -113,7 +113,7 @@ describe Crygen::Types::Enum do
     enum_type.add_constant("Employee")
     enum_type.add_constant("Student")
     enum_type.add_constant("Intern")
-    enum_type.as_flags
+    enum_type.flags
 
     enum_type.generate.should eq(<<-CRYSTAL)
     @[Flags]

--- a/spec/libc_spec.cr
+++ b/spec/libc_spec.cr
@@ -190,7 +190,7 @@ describe Crygen::Types::LibC do
 
     libc_type = Crygen::Types::LibC.new("C")
     libc_type.add_function("getch", "Int32", args)
-    libc_type.add_link("mylink")
+    libc_type.link("mylink")
     libc_type.generate.should eq(<<-CRYSTAL)
     @[Link("mylink")]
     lib C

--- a/src/helpers/annotation.cr
+++ b/src/helpers/annotation.cr
@@ -1,6 +1,6 @@
 # This module provides helper methods for adding annotations to objects easily.
 module Crygen::Helpers::Annotation
-  # Add a `@[Deprecated]` annotation on the method.
+  # Add a `@[Deprecated]` annotation.
   # Returns: an object class itself.
   def as_deprecated : self
     @annotations << CGT::Annotation.new("Deprecated")
@@ -14,7 +14,7 @@ module Crygen::Helpers::Annotation
     self
   end
 
-  # Add a `@[Experimental]` annotation on the method.
+  # Add a `@[Experimental]` annotation.
   # Returns: an object class itself.
   def as_experimental : self
     @annotations << CGT::Annotation.new("Experimental")
@@ -28,7 +28,7 @@ module Crygen::Helpers::Annotation
     self
   end
 
-  # Add a `@[Flags]` annotation on the method.
+  # Add a `@[Flags]` annotation.
   # Returns: an object class itself.
   def as_flags : self
     @annotations << CGT::Annotation.new("Flags")
@@ -42,5 +42,38 @@ module Crygen::Helpers::Annotation
     self
   end
 
-  # Note: Add the @[ThreadLocal], @[AlwaysInline], @[Extern], @[AlwaysInline], @[NoInline], @[Raises], @[CallConvention] annotations.
+  # Add a `@[ThreadLocal]` annotation.
+  # Returns: an object class itself.
+  def as_thread_local : self
+    @annotations << CGT::Annotation.new("ThreadLocal")
+    self
+  end
+
+  # Add a `@[AlwaysInline]` annotation.
+  # Returns: an object class itself.
+  def as_always_inline : self
+    @annotations << CGT::Annotation.new("AlwaysInline")
+    self
+  end
+
+  # Add a `@[Extern]` annotation.
+  # Returns: an object class itself.
+  def as_extern : self
+    @annotations << CGT::Annotation.new("Extern")
+    self
+  end
+
+  # Add a `@[NoInline]` annotation.
+  # Returns: an object class itself.
+  def as_no_inline : self
+    @annotations << CGT::Annotation.new("NoInline")
+    self
+  end
+
+  # Add a `@[CallConvention]` annotation.
+  # Returns: an object class itself.
+  def add_call_convention(name : String) : self
+    @annotations << CGT::Annotation.new("Link").add_arg(name.dump)
+    self
+  end
 end

--- a/src/helpers/annotation.cr
+++ b/src/helpers/annotation.cr
@@ -2,77 +2,77 @@
 module Crygen::Helpers::Annotation
   # Add a `@[Deprecated]` annotation.
   # Returns: an object class itself.
-  def as_deprecated : self
+  def deprecated : self
     @annotations << CGT::Annotation.new("Deprecated")
     self
   end
 
   # Add a `@[Deprecated]` annotation on the method with a custom message.
   # Returns: an object class itself.
-  def as_deprecated(message : String) : self
+  def deprecated(message : String) : self
     @annotations << CGT::Annotation.new("Deprecated").add_arg(message.dump)
     self
   end
 
   # Add a `@[Experimental]` annotation.
   # Returns: an object class itself.
-  def as_experimental : self
+  def experimental : self
     @annotations << CGT::Annotation.new("Experimental")
     self
   end
 
   # Add a `@[Experimental]` annotation on the method with a custom message.
   # Returns: an object class itself.
-  def as_experimental(message : String) : self
+  def experimental(message : String) : self
     @annotations << CGT::Annotation.new("Experimental").add_arg(message.dump)
     self
   end
 
   # Add a `@[Flags]` annotation.
   # Returns: an object class itself.
-  def as_flags : self
+  def flags : self
     @annotations << CGT::Annotation.new("Flags")
     self
   end
 
   # Add a `@[Link]` annotation on the method with the library name.
   # Returns: an object class itself.
-  def add_link(name : String) : self
+  def link(name : String) : self
     @annotations << CGT::Annotation.new("Link").add_arg(name.dump)
     self
   end
 
   # Add a `@[ThreadLocal]` annotation.
   # Returns: an object class itself.
-  def as_thread_local : self
+  def thread_local : self
     @annotations << CGT::Annotation.new("ThreadLocal")
     self
   end
 
   # Add a `@[AlwaysInline]` annotation.
   # Returns: an object class itself.
-  def as_always_inline : self
+  def always_inline : self
     @annotations << CGT::Annotation.new("AlwaysInline")
     self
   end
 
   # Add a `@[Extern]` annotation.
   # Returns: an object class itself.
-  def as_extern : self
+  def extern : self
     @annotations << CGT::Annotation.new("Extern")
     self
   end
 
   # Add a `@[NoInline]` annotation.
   # Returns: an object class itself.
-  def as_no_inline : self
+  def no_inline : self
     @annotations << CGT::Annotation.new("NoInline")
     self
   end
 
   # Add a `@[CallConvention]` annotation.
   # Returns: an object class itself.
-  def add_call_convention(name : String) : self
+  def call_convention(name : String) : self
     @annotations << CGT::Annotation.new("Link").add_arg(name.dump)
     self
   end


### PR DESCRIPTION
## Description

New methods are added to generate standard Crystal annotations easily.
**Breaking change**: The signatures of these methods have been modified and constitute a breaking change.