### PR TITLE
Avoid code's repetitions, simplify nilable types

### DIFF
--- a/src/crygen.cr
+++ b/src/crygen.cr
@@ -1,5 +1,6 @@
 require "./types/**"
 require "./modules/**"
+require "./generators/**"
 
 # **crygen** is a library that allows to generate a Crystal file. It is inspired by the PHP
 # library : [nette/php-generator](https://github.com/nette/php-generator).
@@ -12,4 +13,7 @@ module Crygen
 
   # CGE is an alias of "**C**ry**G**en **E**nums".
   alias ::CGE = Crygen::Enums
+
+  # CGG is an alias of "**C**ry**G**en **G**enerators".
+  alias ::CGG = Crygen::Generators
 end

--- a/src/generators/annotation.cr
+++ b/src/generators/annotation.cr
@@ -1,0 +1,9 @@
+class Crygen::Generators::Annotation
+  def self.generate(annotations : Array(Crygen::Types::Annotation)) : String
+    String.build do |str|
+      annotations.each do |annotation_type|
+        str << annotation_type.generate << "\n"
+      end
+    end
+  end
+end

--- a/src/generators/comment.cr
+++ b/src/generators/comment.cr
@@ -1,0 +1,9 @@
+class Crygen::Generators::Comment
+  def self.generate(comments : Array(String)) : String
+    String.build do |str|
+      comments.each do |comment|
+        str << "# " << comment << "\n"
+      end
+    end
+  end
+end

--- a/src/modules/arg.cr
+++ b/src/modules/arg.cr
@@ -1,9 +1,9 @@
 # Module that is used to store and add the arguments.
 module Crygen::Modules::Arg
-  @args = [] of Tuple(String, String, String | Nil)
+  @args = [] of Tuple(String, String, String?)
 
   # Adds an argument.
-  def add_arg(name : String, type : String, value : String | Nil = nil) : self
+  def add_arg(name : String, type : String, value : String? = nil) : self
     @args << {name, type, value}
     self
   end

--- a/src/modules/arg.cr
+++ b/src/modules/arg.cr
@@ -13,14 +13,12 @@ module Crygen::Modules::Arg
     String.build do |str|
       str << '(' unless @args.empty?
 
-      @args.each_with_index do |arg, i|
+      @args.each_with_index do |arg, index|
         name, type, value = arg
 
         str << name << " : " << type
-        unless value.nil?
-          str << " = " << value
-        end
-        str << ", " if i != @args.size - 1
+        str << " = " << value unless value.nil?
+        str << ", " if index != @args.size - 1
       end
 
       str << ')' unless @args.empty?

--- a/src/modules/class_var.cr
+++ b/src/modules/class_var.cr
@@ -21,9 +21,7 @@ module Crygen::Modules::ClassVar
         name, type, value = class_var
 
         str << "@@" << name << " : " << type
-        unless value.nil?
-          str << " = " << value
-        end
+        str << " = " << value unless value.nil?
         str << "\n"
       end
     end

--- a/src/modules/class_var.cr
+++ b/src/modules/class_var.cr
@@ -1,9 +1,9 @@
 # Module that is used to store class variables.
 module Crygen::Modules::ClassVar
-  @class_vars = [] of Tuple(String, String, String | Nil)
+  @class_vars = [] of Tuple(String, String, String?)
 
   # Adds a class var with default value.
-  def add_class_var(name : String, type : String, value : String | Nil = nil) : self
+  def add_class_var(name : String, type : String, value : String? = nil) : self
     output_value = if type == "String" && !value.nil?
                      value.dump
                    else

--- a/src/modules/instance_var.cr
+++ b/src/modules/instance_var.cr
@@ -1,9 +1,9 @@
 # Module that is used to store and add the instance variables.
 module Crygen::Modules::InstanceVar
-  @instance_vars = [] of Tuple(String, String, String | Nil)
+  @instance_vars = [] of Tuple(String, String, String?)
 
   # Adds an argument with default value.
-  def add_instance_var(name : String, type : String, value : String | Nil = nil) : self
+  def add_instance_var(name : String, type : String, value : String? = nil) : self
     output_value = if type == "String" && !value.nil?
                      value.dump
                    else

--- a/src/modules/instance_var.cr
+++ b/src/modules/instance_var.cr
@@ -20,9 +20,7 @@ module Crygen::Modules::InstanceVar
         name, type, value = instance_var
 
         str << '@' << name << " : " << type
-        unless value.nil?
-          str << " = " << value
-        end
+        str << " = " << value unless value.nil?
         str << "\n"
       end
     end

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -3,7 +3,7 @@ require "./../enums/prop_scope"
 require "./scope"
 
 module Crygen::Modules::Property
-  @properties = [] of Hash(Symbol, String | Nil)
+  @properties = [] of Hash(Symbol, String?)
 
   # Adds a property into object (visibility, name, type, value and scope).
   def add_property(

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -34,10 +34,7 @@ module Crygen::Modules::Property
           str << CGG::Comment.generate(comment.lines)
         end
 
-        unless prop[:scope] == "public"
-          str << prop[:scope] << ' '
-        end
-
+        str << prop[:scope] << ' ' unless prop[:scope] == "public"
         str << prop[:visibility] << ' ' << prop[:name]
         str << " : " << prop[:type] if prop[:type]
         str << " = " << prop[:value] if prop[:value]

--- a/src/modules/property.cr
+++ b/src/modules/property.cr
@@ -31,7 +31,7 @@ module Crygen::Modules::Property
     String.build do |str|
       @properties.each do |prop|
         if comment = prop[:comment]
-          comment.each_line { |line| str << "# " << line << "\n" }
+          str << CGG::Comment.generate(comment.lines)
         end
 
         unless prop[:scope] == "public"

--- a/src/types/alias.cr
+++ b/src/types/alias.cr
@@ -18,7 +18,7 @@ class Crygen::Types::Alias < Crygen::Interfaces::GeneratorInterface
   # Generates an alias.
   def generate : String
     String.build do |str|
-      @comments.each { |comment| str << "# #{comment}\n" }
+      str << CGG::Comment.generate(@comments)
 
       str << "alias " << @name << " = "
 

--- a/src/types/alias.cr
+++ b/src/types/alias.cr
@@ -22,9 +22,9 @@ class Crygen::Types::Alias < Crygen::Interfaces::GeneratorInterface
 
       str << "alias " << @name << " = "
 
-      @types.each_with_index do |type, idx|
+      @types.each_with_index do |type, index|
         str << type
-        str << " | " unless idx == @types.size - 1
+        str << " | " unless index == @types.size - 1
       end
     end
   end

--- a/src/types/annotation.cr
+++ b/src/types/annotation.cr
@@ -14,7 +14,7 @@ require "./../interfaces/generator_interface"
 # end
 # ```
 class Crygen::Types::Annotation < Crygen::Interfaces::GeneratorInterface
-  @args = [] of Tuple(String | Nil, String)
+  @args = [] of Tuple(String?, String)
 
   def initialize(@name : String); end
 

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -54,14 +54,13 @@ class Crygen::Types::Class < Crygen::Interfaces::GeneratorInterface
       str << CGG::Comment.generate(@comments)
       str << CGG::Annotation.generate(@annotations)
 
-      class_type = @type == :abstract ? "abstract class" : "class"
+      str << "abstract " if @type == :abstract
+      str << "class "
+      str << @name << "\n"
 
-      str << class_type << ' ' << @name << "\n"
-
-      generate_mixins.each_line(&line_proc)
-      generate_properties.each_line(&line_proc)
-      generate_instance_vars.each_line(&line_proc)
-      generate_class_vars.each_line(&line_proc)
+      [generate_mixins, generate_properties, generate_instance_vars, generate_class_vars].each do |step|
+        step.each_line(&line_proc)
+      end
 
       can_add_whitespace = false
 

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -51,8 +51,8 @@ class Crygen::Types::Class < Crygen::Interfaces::GeneratorInterface
     String.build do |str|
       line_proc = ->(line : String) { str << "  " + line + "\n" }
 
-      @comments.each { |comment| str << "# #{comment}\n" }
-      @annotations.each { |annotation_type| str << annotation_type.generate + "\n" }
+      str << CGG::Comment.generate(@comments)
+      str << CGG::Annotation.generate(@annotations)
 
       class_type = @type == :abstract ? "abstract class" : "class"
 

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -49,9 +49,8 @@ class Crygen::Types::Enum < Crygen::Interfaces::GeneratorInterface
   # Generates an enum.
   def generate : String
     String.build do |str|
-      @comments.each { |comment| str << "# #{comment}\n" }
-
-      @annotations.each { |annotation_type| str << annotation_type.generate + "\n" }
+      str << CGG::Comment.generate(@comments)
+      str << CGG::Annotation.generate(@annotations)
 
       str << "enum " << @name
       str << " : " << @type if @type

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -23,9 +23,9 @@ class Crygen::Types::Enum < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Annotation
 
   # Array of constants (name and value).
-  @constants = [] of Tuple(String, String | Nil)
+  @constants = [] of Tuple(String, String?)
 
-  def initialize(@name : String, @type : String | Nil = nil); end
+  def initialize(@name : String, @type : String? = nil); end
 
   # Adds a constant into enum (name and value).
   # ```
@@ -40,7 +40,7 @@ class Crygen::Types::Enum < Crygen::Interfaces::GeneratorInterface
   #   Employee
   # end
   # ```
-  def add_constant(name : String, value : String | Nil = nil) : self
+  def add_constant(name : String, value : String? = nil) : self
     @constants << {name, value}
 
     self

--- a/src/types/libc.cr
+++ b/src/types/libc.cr
@@ -84,11 +84,11 @@ class Crygen::Types::LibC < Crygen::Interfaces::GeneratorInterface
   # Generates a C lib.
   def generate : String
     String.build do |str|
-      @annotations.each { |annotation_type| str << annotation_type.generate + "\n" }
-
+      str << CGG::Annotation.generate(@annotations)
       str << "lib " << @name << "\n"
 
       can_add_whitespace = false
+      
       @objects.each do |object|
         str << "\n" if can_add_whitespace == true
         str << "  " << object[1] << ' ' << object[0] << "\n"

--- a/src/types/libc.cr
+++ b/src/types/libc.cr
@@ -88,7 +88,7 @@ class Crygen::Types::LibC < Crygen::Interfaces::GeneratorInterface
       str << "lib " << @name << "\n"
 
       can_add_whitespace = false
-      
+
       @objects.each do |object|
         str << "\n" if can_add_whitespace == true
         str << "  " << object[1] << ' ' << object[0] << "\n"
@@ -102,12 +102,8 @@ class Crygen::Types::LibC < Crygen::Interfaces::GeneratorInterface
       end
       str << "\n" if !@objects.empty? && !@functions.empty?
       @functions.each do |function|
-        if function[:args].empty?
-          str << "  fun " << function[:name]
-        else
-          str << "  fun " << function[:name] << function[:args]
-        end
-
+        str << "  fun " << function[:name]
+        str << function[:args] unless function[:args].empty?
         str << " : " << function[:return_type] << "\n"
       end
       str << "end"

--- a/src/types/libc.cr
+++ b/src/types/libc.cr
@@ -34,7 +34,7 @@ class Crygen::Types::LibC < Crygen::Interfaces::GeneratorInterface
   #   fun getch(arg1 : Int32, arg2 : Int32) : Int32
   # end
   # ```
-  def add_function(name : String, return_type : String, args : Array(Tuple(String, String)) | Nil = nil) : self
+  def add_function(name : String, return_type : String, args : FieldArray? = nil) : self
     @functions << {
       :name        => name,
       :args        => !args.nil? ? generate_args(args) : "",

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -37,7 +37,6 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
   # ```
   def add_annotation(annotation_type : Crygen::Types::Annotation) : self
     @annotations << annotation_type
-
     self
   end
 
@@ -54,7 +53,6 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
   # ```
   def add_body(body : String) : self
     @body += body
-
     self
   end
 
@@ -65,7 +63,7 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
       str << CGG::Annotation.generate(@annotations)
       str << @scope << ' ' unless @scope == :public
       str << "def " << @name << generate_args << " : " << @return_type << "\n"
-      @body.each_line { |line| str << "  #{line}\n" }
+      @body.each_line { |line| str << "  " << line << "\n" }
       str << "end"
     end
   end

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -61,8 +61,8 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
   # Generates the methods.
   def generate : String
     String.build do |str|
-      @comments.each { |comment| str << "# " << comment << "\n" }
-      @annotations.each { |annotation_type| str << annotation_type.generate << "\n" }
+      str << CGG::Comment.generate(@comments)
+      str << CGG::Annotation.generate(@annotations)
       str << @scope << ' ' unless @scope == :public
       str << "def " << @name << generate_args << " : " << @return_type << "\n"
       @body.each_line { |line| str << "  #{line}\n" }
@@ -73,7 +73,7 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
   # Generates the abstract methods.
   protected def generate_abstract_method : String
     String.build do |str|
-      @comments.each { |comment| str << "# " << comment << "\n" }
+      str << CGG::Comment.generate(@comments)
       str << @scope << ' ' unless @scope == :public
       str << "  abstract def " << @name << generate_args << " : " << @return_type << "\n"
     end

--- a/src/types/module.cr
+++ b/src/types/module.cr
@@ -58,6 +58,7 @@ class Crygen::Types::Module < Crygen::Interfaces::GeneratorInterface
   # Generates a module.
   def generate : String
     String.build do |str|
+      str << CGG::Comment.generate(@comments)
       @comments.each { |comment| str << "# " << comment << "\n" }
       str << "module " << @name << "\n"
 

--- a/src/types/module.cr
+++ b/src/types/module.cr
@@ -59,8 +59,8 @@ class Crygen::Types::Module < Crygen::Interfaces::GeneratorInterface
   def generate : String
     String.build do |str|
       str << CGG::Comment.generate(@comments)
-      @comments.each { |comment| str << "# " << comment << "\n" }
-      str << "module " << @name << "\n"
+      str << "module "
+      str << @name << "\n"
 
       can_add_whitespace = false
 

--- a/src/types/struct.cr
+++ b/src/types/struct.cr
@@ -34,22 +34,25 @@ class Crygen::Types::Struct < Crygen::Interfaces::GeneratorInterface
     String.build do |str|
       line_proc = ->(line : String) { str << "  " + line + "\n" }
 
-      @comments.each { |comment| str << "# " << comment << "\n" }
-      @annotations.each { |annotation_type| str << annotation_type.generate + "\n" }
+      str << CGG::Comment.generate(@comments)
+      str << CGG::Annotation.generate(@annotations)
+
       str << "struct " << @name << "\n"
-      generate_mixins.each_line(&line_proc)
-      generate_properties.each_line(&line_proc)
-      generate_instance_vars.each_line(&line_proc)
-      generate_class_vars.each_line(&line_proc)
+
+      [generate_mixins, generate_properties, generate_instance_vars, generate_class_vars].each do |method|
+        method.each_line(&line_proc)
+      end
 
       can_add_whitespace = false
       @methods.each do |method|
         str << "\n" if can_add_whitespace == true
         str << method.generate.each_line(&line_proc)
+
         if can_add_whitespace == false
           can_add_whitespace = true
         end
       end
+
       str << "end"
     end
   end


### PR DESCRIPTION
## Description

To make code maintainable over time, repetition in the code must be avoided. Also, the nilable types (like `| Nil`) are replaced by `?`.
Also, annotation and comment generators are moved into the `src/generators` directory.