### PR TITLE
Update the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crystal: ["1.14", "1.15", "1.16", latest, nightly]
+        crystal: ["1.14", "1.15", "1.16", "1.17", latest, nightly]
     runs-on: ubuntu-latest
     steps:
       - name: Download source

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,4 +24,4 @@ jobs:
       - name: Run tests
         run: crystal spec --order=random
       - name: Check formatting
-        run: crystal tool format && bin/ameba
+        run: bin/ameba


### PR DESCRIPTION
## Description

To make crygen compatible, Crystal 1.17 is added in the matrix. Then, only ameba will be executed for cheching the code format.