### PR TITLE
Trigger `push` only on the `main` branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 on:
   push:
-  pull_request:
     branches: [ "main" ]
+  pull_request:
   schedule:
   - cron: '0 6 * * 6'
 


### PR DESCRIPTION
## Description

To avoid having too much tasks, the `push` event will be triggered when merging / commiting changes into the main branch. When a user will push commits on their PRs, only `pull_request` will be trigerred.
