### PR TITLE
Add several constants with `#add_constants`

### DIFF
--- a/spec/enum_spec.cr
+++ b/spec/enum_spec.cr
@@ -19,6 +19,46 @@ describe Crygen::Types::Enum do
     enum_type.to_s.should eq(expected)
   end
 
+  it "creates an enum (with #add_constants method)" do
+    enum_type = Crygen::Types::Enum.new("Person")
+    enum_type.add_constants(
+      {"Employee", nil},
+      {"Student", nil},
+      {"Intern", nil},
+    )
+
+    expected = <<-CRYSTAL
+    enum Person
+      Employee
+      Student
+      Intern
+    end
+    CRYSTAL
+
+    enum_type.generate.should eq(expected)
+    enum_type.to_s.should eq(expected)
+  end
+
+  it "creates an enum with the value of constants (with #add_constants method)" do
+    enum_type = Crygen::Types::Enum.new("Person")
+    enum_type.add_constants(
+      {"Employee", "1"},
+      {"Student", "2"},
+      {"Intern", "3"},
+    )
+
+    expected = <<-CRYSTAL
+    enum Person
+      Employee = 1
+      Student = 2
+      Intern = 3
+    end
+    CRYSTAL
+
+    enum_type.generate.should eq(expected)
+    enum_type.to_s.should eq(expected)
+  end
+
   it "creates an enum with one method" do
     method_is_student = Crygen::Types::Method.new("student?", "Bool")
     method_is_student.add_body("self == Person::Student")

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -54,6 +54,29 @@ class Crygen::Types::Enum < Crygen::Interfaces::GeneratorInterface
     self
   end
 
+  # Adds several constants into enum (name and value).
+  # ```
+  # enum_type = Crygen::Types::Enum.new("Person")
+  # enum_type.add_constants(
+  #   {"Employee", "1"}, {"Student", "2"}, {"Intern", "3"}
+  # )
+  # ```
+  #
+  # Output:
+  # ```
+  # enum Person
+  #   Employee = 1
+  #   Student = 2
+  #   Intern = 3
+  # end
+  # ```
+  def add_constants(*constants : Tuple(String, String?)) : self
+    constants.each do |name, value|
+      self.add_constant(name, value)
+    end
+    self
+  end
+
   # Generates an enum.
   def generate : String
     String.build do |str|

--- a/src/types/enum.cr
+++ b/src/types/enum.cr
@@ -66,8 +66,8 @@ class Crygen::Types::Enum < Crygen::Interfaces::GeneratorInterface
   # ```
   # enum Person
   #   Employee = 1
-  #   Student = 2
-  #   Intern = 3
+  #   Student  = 2
+  #   Intern   = 3
   # end
   # ```
   def add_constants(*constants : Tuple(String, String?)) : self


### PR DESCRIPTION
> [!NOTE]
> If this PR is intended to resolve an issue, please indicate the issue reference.

## Description

To easily add several constants, the `#add_constants` is added.

```crystal
def add_constants(*constants : Tuple(String, String?)) : self
```

## Issue reference(s)

_Issue reference: #47_