### PR TITLE
Possibility to add several args into an argument.

### DIFF
--- a/spec/method_spec.cr
+++ b/spec/method_spec.cr
@@ -138,4 +138,21 @@ describe Crygen::Types::Method do
     method_type.generate.should eq(expected)
     method_type.to_s.should eq(expected)
   end
+
+  it "adds several arguments with #add_args" do
+    expected = <<-CRYSTAL
+    def foo(bar : String, age : Int32 = 42, flag : Bool) : Nil
+    end
+    CRYSTAL
+
+    method_type = CGT::Method.new("foo", "Nil")
+    method_type.add_args(
+      {"bar", "String", nil},
+      {"age", "Int32", "42"},
+      {"flag", "Bool", nil}
+    )
+
+    method_type.generate.should eq(expected)
+    method_type.to_s.should eq(expected)
+  end
 end

--- a/src/modules/arg.cr
+++ b/src/modules/arg.cr
@@ -8,6 +8,14 @@ module Crygen::Modules::Arg
     self
   end
 
+  # Adds several arguments.
+  def add_args(*args : Tuple(String, String, String?)) : self
+    args.each do |name, type, value|
+      self.add_arg(name, type, value)
+    end
+    self
+  end
+
   # Generate the args.
   def generate_args : String
     String.build do |str|


### PR DESCRIPTION
> [!NOTE]
> If this PR is intended to resolve an issue, please indicate the issue reference.

## Description

Thanks to `#add_args`, adding several arguments is possible.

```crystal
method_type = CGT::Method.new("foo", "Nil")
method_type.add_args(
  {"bar", "String", nil},
  {"age", "Int32", "42"},
  {"flag", "Bool", nil}
)
```

```crystal
def foo(bar : String, age : Int32 = 42, flag : Bool) : Nil
end
```

## Issue reference(s)

_Issue reference: #48_ 