### PR TITLE
Fix abstract methods

### DIFF
--- a/spec/class/abstract_class_spec.cr
+++ b/spec/class/abstract_class_spec.cr
@@ -22,7 +22,7 @@ describe Crygen::Types::Class do
 
       class_type = test_person_class()
       class_type.as_abstract
-      class_type.add_method(CGT::Method.new("full_name", "String"))
+      class_type.add_method(CGT::Method.new("full_name", "String").as_abstract)
       class_type.generate.should eq(expected)
       class_type.to_s.should eq(expected)
     end
@@ -39,9 +39,30 @@ describe Crygen::Types::Class do
       class_type = test_person_class()
       class_type.as_abstract
       class_type.add_methods(
-        CGT::Method.new("first_name", "String"),
-        CGT::Method.new("last_name", "String"),
-        CGT::Method.new("full_name", "String")
+        CGT::Method.new("first_name", "String").as_abstract,
+        CGT::Method.new("last_name", "String").as_abstract,
+        CGT::Method.new("full_name", "String").as_abstract
+      )
+      class_type.generate.should eq(expected)
+      class_type.to_s.should eq(expected)
+    end
+
+    it "creates an abstract class with abstract and non-abstract methods" do
+      expected = <<-CRYSTAL
+      abstract class Person
+        abstract def abstract_method : String
+
+        def non_abstract_method : String
+          "Hello world"
+        end
+      end
+      CRYSTAL
+
+      class_type = test_person_class()
+      class_type.as_abstract
+      class_type.add_methods(
+        CGT::Method.new("abstract_method", "String").as_abstract,
+        CGT::Method.new("non_abstract_method", "String").add_body("Hello world".dump)
       )
       class_type.generate.should eq(expected)
       class_type.to_s.should eq(expected)

--- a/spec/method_spec.cr
+++ b/spec/method_spec.cr
@@ -155,4 +155,45 @@ describe Crygen::Types::Method do
     method_type.generate.should eq(expected)
     method_type.to_s.should eq(expected)
   end
+
+  it "creates an abstract method" do
+    expected = <<-CRYSTAL
+    abstract def major?(age : Int8 = 18, min_majority : Int8 = 22) : Bool
+    CRYSTAL
+
+    method_type = CGT::Method.new("major?", "Bool")
+    method_type.add_arg("age", "Int8", "18")
+    method_type.add_arg("min_majority", "Int8", "22")
+    method_type.as_abstract
+    method_type.generate.should eq(expected)
+    method_type.to_s.should eq(expected)
+  end
+
+  it "creates a protected abstract method" do
+    expected = <<-CRYSTAL
+    protected abstract def major?(age : Int8 = 18, min_majority : Int8 = 22) : Bool
+    CRYSTAL
+
+    method_type = CGT::Method.new("major?", "Bool")
+    method_type.add_arg("age", "Int8", "18")
+    method_type.add_arg("min_majority", "Int8", "22")
+    method_type.as_protected
+    method_type.as_abstract
+    method_type.generate.should eq(expected)
+    method_type.to_s.should eq(expected)
+  end
+
+  it "creates a private abstract method" do
+    expected = <<-CRYSTAL
+    private abstract def major?(age : Int8 = 18, min_majority : Int8 = 22) : Bool
+    CRYSTAL
+
+    method_type = CGT::Method.new("major?", "Bool")
+    method_type.add_arg("age", "Int8", "18")
+    method_type.add_arg("min_majority", "Int8", "22")
+    method_type.as_private
+    method_type.as_abstract
+    method_type.generate.should eq(expected)
+    method_type.to_s.should eq(expected)
+  end
 end

--- a/src/modules/method.cr
+++ b/src/modules/method.cr
@@ -14,4 +14,26 @@ module Crygen::Modules::Method
     @methods += methods.to_a
     self
   end
+
+  protected def generate_abstract_methods(str : IO, methods : Array(CGT::Method), whitespace : Bool)
+    methods.each do |method|
+      str << "\n" if whitespace == true
+      str << method.generate_abstract_method.each_line { |line| str << "  " + line + "\n" }
+
+      if whitespace == false && @type == :normal
+        whitespace = true
+      end
+    end
+  end
+
+  protected def generate_normal_methods(str : IO, methods : Array(CGT::Method), whitespace : Bool)
+    methods.each do |method|
+      str << "\n" if whitespace == true
+      str << method.generate.each_line { |line| str << "  " + line + "\n" }
+
+      if whitespace == false && @type == :normal
+        whitespace = true
+      end
+    end
+  end
 end

--- a/src/types/class.cr
+++ b/src/types/class.cr
@@ -65,19 +65,17 @@ class Crygen::Types::Class < Crygen::Interfaces::GeneratorInterface
         step.each_line(&line_proc)
       end
 
-      can_add_whitespace = false
+      whitespace = false
 
-      @methods.each do |method|
-        str << "\n" if can_add_whitespace == true
+      grouped_methods = @methods.group_by(&.type)
 
-        case @type
-        when :normal   then str << method.generate.each_line(&line_proc)
-        when :abstract then str << method.generate_abstract_method
-        end
+      if grouped_methods[:abstract]?
+        generate_abstract_methods(str, grouped_methods[:abstract], whitespace)
+        str << "\n" if grouped_methods[:normal]?
+      end
 
-        if can_add_whitespace == false && @type == :normal
-          can_add_whitespace = true
-        end
+      if grouped_methods[:normal]?
+        generate_normal_methods(str, grouped_methods[:normal], whitespace)
       end
 
       str << "end"

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -20,10 +20,28 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
   include Crygen::Modules::Arg
   include Crygen::Modules::Annotation
 
+  getter type : Symbol = :normal
+
   # Body content.
   @body : String = ""
 
   def initialize(@name : String, @return_type : String); end
+
+  # Set as an abstract method.
+  # ```
+  # class_type = CGT::Class.new("Person")
+  # class_type.as_abstract
+  # ```
+  #
+  # Output:
+  # ```
+  # abstract class Person
+  # end
+  # ```
+  def as_abstract : self
+    @type = :abstract
+    self
+  end
 
   # Add a code into method.
   # ```

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -85,6 +85,7 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
   protected def generate_abstract_method : String
     String.build do |str|
       str << CGG::Comment.generate(@comments)
+      str << CGG::Annotation.generate(@annotations)
       str << @scope << ' ' unless @scope == :public
       str << "abstract def " << @name << generate_args << " : " << @return_type
     end

--- a/src/types/method.cr
+++ b/src/types/method.cr
@@ -60,8 +60,17 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
     self
   end
 
-  # Generates the methods.
+  # Generates the method.
   def generate : String
+    if @type == :abstract
+      self.generate_abstract_method
+    else
+      self.generate_normal_method
+    end
+  end
+
+  # Generates the normal (non-abstract) method.
+  protected def generate_normal_method : String
     String.build do |str|
       str << CGG::Comment.generate(@comments)
       str << CGG::Annotation.generate(@annotations)
@@ -72,12 +81,12 @@ class Crygen::Types::Method < Crygen::Interfaces::GeneratorInterface
     end
   end
 
-  # Generates the abstract methods.
+  # Generates the abstract method.
   protected def generate_abstract_method : String
     String.build do |str|
       str << CGG::Comment.generate(@comments)
       str << @scope << ' ' unless @scope == :public
-      str << "  abstract def " << @name << generate_args << " : " << @return_type << "\n"
+      str << "abstract def " << @name << generate_args << " : " << @return_type
     end
   end
 


### PR DESCRIPTION
> [!NOTE]
> If this PR is intended to resolve an issue, please indicate the issue reference.

## Description

Due to the referenced issue, it was impossible to generate normal methods in an abstract class. With these changes, it's possible to choose if methods will be set as abstract or not.

## Issue reference(s)

Issue reference : #59