### PR TITLE
Update the CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        crystal: [ "1.14", "1.15", "1.16", "1.17", latest, nightly ]
+        crystal: [ "1.16", "1.17", "1.18", latest, nightly ]
     runs-on: ubuntu-latest
     steps:
     - name: Download source


### PR DESCRIPTION
## Description

This PR provides changes for testing this package with the latest versions of Crystal (from 1.16 to 1.18, latest and nighly included). The CI job name is now `test` instead of `build`.

