### PR TITLE
Remove `pull` and `sync` tasks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -9,5 +9,3 @@ tasks:
     cmd: crystal docs -o api
   test:
     cmd: crystal spec -p
-  pull:
-    cmd: git pull origin main --rebase


### PR DESCRIPTION
## Description

As the `af_git_sync` function is added in the Codeberg's repo for automating the Git repo sync (https://codeberg.org/tamdaz/automafish/src/branch/main/functions/af_git_sync.fish#L2-L11), the `sync` command will be now removed. Also, the `pull` task is no longer necessary.