### PR TITLE
Make `comments` property protected

### DIFF
--- a/src/modules/comment.cr
+++ b/src/modules/comment.cr
@@ -1,6 +1,6 @@
 # Module that is used to store and add the comments.
 module Crygen::Modules::Comment
-  getter comments = [] of String
+  protected getter comments = [] of String
 
   # Add a line or multiline comments.
   def add_comment(value : String) : self


### PR DESCRIPTION
## Description

I'd like to set the `comments` property as protected because it must be used internally for this shard. Otherwise, the version would be incremented according to semver. Preferably, the patch version will be incremented.