### PR TITLE
Change the argument type to `UInt8` for adding/removing the indents.

### DIFF
--- a/src/utils/indentation.cr
+++ b/src/utils/indentation.cr
@@ -8,23 +8,15 @@ class Crygen::Utils::Indentation
   @@saved_number : Int32 = 0
 
   # Adds the indentation with the defined size.
-  def self.add_indent(size : Number = 2) : Void
-    if size < 0
-      raise "You can't use the negative number for adding the indentation."
-    end
-
+  def self.add_indent(size : UInt8 = 2) : Void
     @@number_of_spaces += size
   end
 
   # Removes the indentation with the defined size.
-  def self.remove_indent(size : Number = 2) : Void
-    if size < 0
-      raise "You can't use the negative number for removing the indentation."
-    end
+  def self.remove_indent(size : UInt8 = 2) : Void
+    @@number_of_spaces -= size
 
-    if @@number_of_spaces - size >= 0
-      @@number_of_spaces -= size
-    else
+    if @@number_of_spaces < 0
       @@number_of_spaces = 0
     end
   end


### PR DESCRIPTION
## Description

This PR fixes a bug related to indentation. It is possible for the value used to manage the indentation size to be negative. To avoid this problem, exceptions can be thrown if the value of the argument _(indentation size)_ is incorrect.
